### PR TITLE
Better handling cases where recurring orders are missing.

### DIFF
--- a/pmpro-proration.php
+++ b/pmpro-proration.php
@@ -114,7 +114,7 @@ function pmprorate_pmpro_checkout_level( $level ) {
 			
 			$days_passed = ceil( ( $today - $payment_date ) / 3600 / 24 );
 			$per_passed = $days_passed / $days_in_period;        //as a % (decimal)
-			$per_left   = 1 - $per_passed;
+			$per_left   = max( 1 - $per_passed, 0 );
 			
 			/*
 				Now figure out how to adjust the price.
@@ -161,10 +161,10 @@ function pmprorate_pmpro_checkout_level( $level ) {
 			}
 			
 			$days_passed = ceil( ( $today - $payment_date ) / 3600 / 24 );
-			$per_passed = $days_passed / $days_in_period;        //as a % (decimal)			
-			$per_left   = 1 - $per_passed;
-			$credit = $morder->subtotal * $per_left;			
-			
+			$per_passed  = $days_passed / $days_in_period;        //as a % (decimal)			
+			$per_left    = max( 1 - $per_passed, 0 );
+			$credit      = $morder->subtotal * $per_left;			
+
 			$level->initial_payment = round( $level->initial_payment - $credit, 2 );
 
 			//just in case we have a negative payment


### PR DESCRIPTION
Main issue:
- PayPal IPNs not set up correctly
- User checks out for weekly recurring level
- Recurring orders not created in PMPro since IPN not working
- When user upgrades to annual membership, PMPro Proration tries to "make up" missed payments

This change essentially prevents the initial payment from being changed if the user would be charged a greater amount after prorations.

Also fixes an issue where the initial payment would be free in the above scenario if the user upgraded to another weekly level with a higher initial payment price. User will now instead pay full price if recurring orders were not created.