### PR TITLE
Marking the plugin as MMPU-incompatible

### DIFF
--- a/pmpro-proration.php
+++ b/pmpro-proration.php
@@ -506,6 +506,15 @@ function pmproproate_daily_check_for_membership_changes() {
 add_action( 'pmpro_cron_expire_memberships', 'pmproproate_daily_check_for_membership_changes' );
 
 /**
+ * Mark the plugin as MMPU-incompatible.
+ */
+  function pmproprorate_mmpu_incompatible_add_ons( $incompatible ) {
+	$incompatible[] = 'PMPro Prorations Add On';
+	return $incompatible;
+}
+add_filter( 'pmpro_mmpu_incompatible_add_ons', 'pmproprorate_mmpu_incompatible_add_ons' );
+
+/**
  * Add links to the plugin row meta
  */
 function pmproproate_plugin_row_meta( $links, $file ) {


### PR DESCRIPTION
Marking the plugin as MMPU-incompatible for PMPro v3.0 update.