### PR TITLE
Delayed downgrades overhaul

### DIFF
--- a/classes/pmprorate-class-downgrade.php
+++ b/classes/pmprorate-class-downgrade.php
@@ -1,0 +1,445 @@
+<?php
+
+/**
+ * The PMPro Prorations downgrade object.
+ *
+ * @since TBD
+ */
+class PMProrate_Downgrade {
+	/**
+	 * The ID of the group entry.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	protected $id;
+
+	/**
+	 * The user ID for the downgrade.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	protected $user_id;
+
+	/**
+	 * The level ID that the user will be downgraded from.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	protected $original_level_id;
+
+	/**
+	 * The level ID that the user will be downgraded to.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	protected $new_level_id;
+
+	/**
+	 * The ID of the order containing the downgrade asynchronous checkout data.
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	protected $downgrade_order_id;
+
+	/**
+	 * The status of this group.
+	 *
+	 * 'pending' => The downgrade has not yet occured.
+	 * 'downgraded_on_renewal' => The downgrade has been completed on a renwal payment.
+	 * 'downgraded_on_expiration' => The downgrade has been completed when the original level expired.
+	 * 'lost_original_level' => The user lost the original level before the downgrade could be completed.
+	 * 'error' => There was an error processing the downgrade.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected $status;
+
+	/**
+	 * Get a downgrade object by ID.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $downgrade The group ID to populate.
+	 */
+	public function __construct( $downgrade ) {
+		global $wpdb;
+
+		if ( is_int( $downgrade ) ) {
+			$data = $wpdb->get_row(
+				$wpdb->prepare(
+					"SELECT * FROM {$wpdb->pmprorate_downgrades} WHERE id = %d",
+					$downgrade
+				)
+			);
+
+			if ( ! empty( $data ) ) {
+				$this->id                 = (int)$data->id;
+				$this->user_id            = (int)$data->user_id;
+				$this->original_level_id  = (int)$data->original_level_id;
+				$this->new_level_id       = (int)$data->new_level_id;
+				$this->downgrade_order_id = (int)$data->downgrade_order_id;
+				$this->status             = $data->status;
+			}
+		}
+	}
+
+	/**
+	 * Get the list of downgrades based on query arguments.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args The query arguments to use to retrieve downgrades.
+	 *
+	 * @return PMProrate_Downgrade[] The list of groups.
+	 */
+	public static function get_downgrades( $args = array() ) {
+		global $wpdb;
+
+		$sql_query = "SELECT id FROM {$wpdb->pmprorate_downgrades}";
+
+		$prepared = array();
+		$where    = array();
+		$orderby  = isset( $args['orderby'] ) ? $args['orderby'] : '`id` DESC';
+		$limit    = isset( $args['limit'] ) ? (int) $args['limit'] : 100;
+
+		// Detect unsupported orderby usage.
+		if ( $orderby !== preg_replace( '/[^a-zA-Z0-9\s,`]/', ' ', $orderby ) ) {
+			return [];
+		}
+
+		// Filter by ID.
+		if ( isset( $args['id'] ) ) {
+			$where[]    = 'id = %d';
+			$prepared[] = $args['id'];
+		}
+
+		// Filter by user ID.
+		if ( isset( $args['user_id'] ) ) {
+			$where[]    = 'user_id = %d';
+			$prepared[] = $args['user_id'];
+		}
+
+		// Filter by original level ID.
+		if ( isset( $args['original_level_id'] ) ) {
+			$where[]    = 'original_level_id = %d';
+			$prepared[] = $args['original_level_id'];
+		}
+
+		// Filter by new level ID.
+		if ( isset( $args['new_level_id'] ) ) {
+			$where[]    = 'new_level_id = %d';
+			$prepared[] = $args['new_level_id'];
+		}
+
+		// Filter by downgrade order ID.
+		if ( isset( $args['downgrade_order_id'] ) ) {
+			$where[]    = 'downgrade_order_id = %d';
+			$prepared[] = $args['downgrade_order_id'];
+		}
+
+		// Filter by status.
+		if ( isset( $args['status'] ) ) {
+			$where[]    = 'status = %s';
+			$prepared[] = $args['status'];
+		}
+
+		// Maybe filter the data.
+		if ( ! empty( $where ) ) {
+			$sql_query .= ' WHERE ' . implode( ' AND ', $where );
+		}
+
+		// Add the order and limit.
+		$sql_query .= " ORDER BY {$orderby} LIMIT {$limit}";
+
+		// Prepare the query.
+		if ( ! empty( $prepared ) ) {
+			$sql_query = $wpdb->prepare( $sql_query, $prepared );
+		}
+
+		// Get the data.
+		$downgrade_ids = $wpdb->get_col( $sql_query );
+		if ( empty( $downgrade_ids ) ) {
+			return array();
+		}
+
+		// Return the list of groups.
+		$downgrades = array();
+		foreach ( $downgrade_ids as $downgrade_id ) {
+			$downgrade = new self( (int)$downgrade_id );
+			if ( ! empty( $downgrade->id ) ) {
+				$downgrades[] = $downgrade;
+			}
+		}
+		return $downgrades;
+	}
+
+	/**
+	 * Create a new downgrade.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $user_id The user ID to be downgraded.
+	 * @param int $original_level_id The level ID that the user will be downgraded from.
+	 * @param int $new_level_id The level ID that the user will be downgraded to.
+	 * @param int $downgrade_order_id The ID of the order containing the downgrade asynchronous checkout data.
+	 *
+	 * @return bool|PMProrate_Downgrade The new downgrade object or false if the downgrade could not be created.
+	 */
+	public static function create( $user_id, $original_level_id, $new_level_id, $downgrade_order_id ) {
+		global $wpdb;
+
+		// Validate the passed data.
+		if (
+			! is_numeric( $user_id ) || (int) $user_id <= 0 ||
+			! is_numeric( $original_level_id ) || (int) $original_level_id <= 0 ||
+			! is_numeric( $new_level_id ) || (int) $new_level_id < 0 ||
+			! is_numeric( $downgrade_order_id ) || (int) $downgrade_order_id <= 0
+		) {
+			return false;
+		}
+
+		// Create the group in the database.
+		$wpdb->insert(
+			$wpdb->pmprorate_downgrades,
+			array(
+				'user_id'            => $user_id,
+				'original_level_id'  => $original_level_id,
+				'new_level_id'       => $new_level_id,
+				'downgrade_order_id' => $downgrade_order_id,
+				'status'             => 'pending',
+			),
+		);
+
+		// Check if the insert failed. This could be the case if the entry already existed.
+		if ( empty( $wpdb->insert_id ) ) {
+			return false;
+		}
+
+		// Return the new group object.
+		return new self( $wpdb->insert_id );
+	}
+
+	/**
+	 * Magic getter to retrieve protected properties.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $name The name of the property to retrieve.
+	 * @return mixed The value of the property.
+	 */
+	public function __get( $name ) {
+		if ( property_exists( $this, $name ) ) {
+			return $this->$name;
+		}
+	}
+
+	/**
+	 * Magic isset to check protected properties.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $name The name of the property to check.
+	 * @return bool Whether the property is set.
+	 */
+	public function __isset( $name ) {
+		if ( property_exists( $this, $name ) ) {
+			return isset( $this->$name );
+		}
+		return false;
+	}
+
+	/**
+	 * Update the downgrade status.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $status The new status.
+	 */
+	public function update_status( $status ) {
+		global $wpdb;
+
+		// Make sure that the status is valid.
+		if ( ! in_array( $status, array( 'pending', 'downgraded_on_renewal', 'downgraded_on_expiration', 'lost_original_level', 'error' ) ) ) {
+			return;
+		}
+
+		// Update the status.
+		$this->status = $status;
+		$wpdb->update(
+			$wpdb->pmprorate_downgrades,
+			array(
+				'status' => $this->status,
+			),
+			array(
+				'id' => $this->id,
+			),
+		);
+
+		// If the order is now in an error state, send an email to the admin.
+		if ( $this->status === 'error' ) {
+			$data = array(
+				'display_name' => get_userdata( $this->user_id )->display_name,
+				'sitename' => get_bloginfo( 'name' ),
+				'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $this->user_id . '&pmpro_member_edit_panel=pmprorate_downgrades' ),
+			);
+			$email_admin = new PMProEmail();
+			$email_admin->template = 'delayed_downgrade_error_admin';
+			$email_admin->email = get_bloginfo( 'admin_email' );
+			$email_admin->data = $data;
+			$email_admin->sendEmail();
+		}
+	}
+
+	/**
+	 * Process the downgrade.
+	 *
+	 * @since TBD
+	 *
+	 * @param MemberOrder|null $renewal_order The renewal order object if the downgrade is being processed on a renewal payment. Null if the downgrade is being processed on expiration.
+	 *
+	 * @return bool Whether the downgrade was processed.
+	 */
+	public function process( $renewal_order = null ) {
+		global $pmpro_level;
+
+		// Get the order witih the downgrade metadata.
+		$downgrade_order = MemberOrder::get_order( $this->downgrade_order_id );
+		if ( empty( $downgrade_order->id ) ) {
+			// If we can't get the order with the downgrade metadata, bail.
+			$this->update_status( 'error' );
+			return false;
+		}
+
+		// We are downgrading. Set the $_REQUEST variables for the checkout that we are going to complete asynchronously.
+		pmpro_pull_checkout_data_from_order( $downgrade_order );
+
+		// Make sure that we have data for the level that we are downgrading to.
+		if ( empty( $pmpro_level ) || empty( $pmpro_level->id ) ) {
+			$this->update_status( 'error' );
+			return false;
+		}
+
+		// If we are processing a renewal order, put it in the place of the downgrade order so that the checkout is completed for the renewal order.
+		if ( ! empty( $renewal_order ) ) {
+			$downgrade_order = $renewal_order;
+		}
+
+		// Set the memberhsip ID for the subscription and all orders in that subscription to the level that we are downgrading to.
+		$subscription = $downgrade_order->get_subscription();
+		if ( ! empty( $subscription ) ) {
+			// Update the subscription.
+			$subscription->set( 'membership_level_id', $pmpro_level->id );
+			$subscription->save();
+
+			// Update the orders in the subscription.
+			$subscription_orders = $subscription->get_orders();
+			foreach( $subscription_orders as $subscription_order ) {
+				$subscription_order->membership_id = $pmpro_level->id;
+				$subscription_order->saveOrder();
+			}
+
+			// Make sure that the order object is updated with the new membership level ID.
+			$downgrade_order->membership_id = $pmpro_level->id;
+		} else {
+			// If this is not a subscription, just update the membership level ID on the order.
+			$downgrade_order->membership_id = $pmpro_level->id;
+			$downgrade_order->saveOrder();
+		}
+
+		// Prevent checkout emails from being sent.
+		add_filter( 'pmpro_send_checkout_emails', '__return_false' );
+
+		// Complete the checkout asynchronously.
+		if (! pmpro_complete_async_checkout( $downgrade_order ) ) {
+			// If the checkout failed, bail.
+			$this->update_status( 'error' );
+			return false;
+		}
+
+		// Remove the filter that prevents checkout emails from being sent.
+		remove_filter( 'pmpro_send_checkout_emails', '__return_false' );
+
+		// Mark this downgrade as completed.
+		$this->update_status( 'downgraded_on_' . ( ! empty( $renewal_order ) ? 'renewal' : 'expiration' ) );
+		
+		// Prepare emails stating that the downgrade has been processed.
+		$user = get_userdata( $this->user_id );
+		$data = array(
+			'display_name' => $user->display_name,
+			'sitename' => get_bloginfo( 'name' ),
+			'login_url' => wp_login_url(),
+			'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $user_id . '&pmpro_member_edit_panel=pmprorate_downgrades' ),
+		);
+
+		// Send email to user.
+		$data['header_name'] = $user->display_name;
+		$email = new PMProEmail();
+		$email->template = 'delayed_downgrade_processed';
+		$email->email = $user->user_email;
+		$email->data = $data;
+		$email->sendEmail();
+
+		// Send email to the site admin.
+		unset( $data['header_name'] );
+		$email_admin = new PMProEmail();
+		$email_admin->template = 'delayed_downgrade_processed_admin';
+		$email_admin->email = get_bloginfo( 'admin_email' );
+		$email_admin->data = $data;
+		$email_admin->sendEmail();
+		}
+
+	/**
+	 * Get downgrade text to show to the user.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|false The downgrade text or false if the downgrade text could not be retrieved.
+	 */
+	public function get_downgrade_text() {
+		// Get the name of the levels that are being downgraded to and from.
+		$downgrading_from_level = pmpro_getLevel( $this->original_level_id );
+		$downgrading_from_level_name = empty( $downgrading_from_level ) ? sprintf( __( '[deleted level #%d]', 'pmpro-prorate' ), $this->original_level_id ) : $downgrading_from_level->name;
+		$downgrading_to_level = pmpro_getLevel( $this->new_level_id );
+		$downgrading_to_level_name = empty( $downgrading_to_level ) ? sprintf( __( '[deleted level #%d]', 'pmpro-prorate' ), $this->new_level_id ) : $downgrading_to_level->name;
+
+		// Get the order for this downgrade.
+		$order = MemberOrder::get_order( $this->downgrade_order_id );
+		if ( empty( $order ) ) {
+			// If we don't have an order, then we're not going to be able to process the downgrade.
+			$this->update_status( 'error' );
+			return false;
+		}
+
+		// Get the next payment date for the user's current subscription.
+		$subscription = $order->get_subscription();
+		$subscription_next_payment_date = empty( $subscription ) ? null : $subscription->get_next_payment_date();
+
+		// Get the expiration date for the user's current membership.
+		$level = pmpro_getSpecificMembershipLevelForUser( $order->user_id, $order->membership_id );
+		$expiration_date = ( empty( $level ) || empty( $level->enddate ) ) ? null : $level->enddate;
+
+		// Generate the downgrade text and return.
+		if ( empty( $subscription_next_payment_date ) && empty( $expiration_date ) ) {
+			// If we don't have a next payment date for the subscription or an expiration date for the membership, then we don't know when the downgrade will be processed.
+			return sprintf( __( 'Your %s membership will be downgraded to %s.', 'pmpro-prorate' ), $downgrading_from_level_name, $downgrading_to_level_name );
+		} elseif ( empty( $expiration_date) || $subscription_next_payment_date < $expiration_date ) {
+			// If we don't have an expiration date or the next payment date is before the expiration date, then the downgrade will be processed on the next payment date.
+			return sprintf( __( 'Your %s membership will be downgraded to %s when your subscription renews on %s.', 'pmpro-prorate' ), $downgrading_from_level_name, $downgrading_to_level_name, date_i18n( get_option( 'date_format' ), $subscription_next_payment_date ) );
+		} else {
+			// If we have an expiration date and the next payment date is after the expiration date, then the downgrade will be processed on the expiration date.
+			return sprintf( __( 'Your %s membership will be downgraded to %s when it expires on %s.', 'pmpro-prorate' ), $downgrading_from_level_name, $downgrading_to_level_name, date_i18n( get_option( 'date_format' ), $expiration_date ) );
+		}
+	}
+}

--- a/classes/pmprorate-class-downgrade.php
+++ b/classes/pmprorate-class-downgrade.php
@@ -408,9 +408,7 @@ class PMProrate_Downgrade {
 	 * @return string|false The downgrade text or false if the downgrade text could not be retrieved.
 	 */
 	public function get_downgrade_text() {
-		// Get the name of the levels that are being downgraded to and from.
-		$downgrading_from_level = pmpro_getLevel( $this->original_level_id );
-		$downgrading_from_level_name = empty( $downgrading_from_level ) ? sprintf( __( '[deleted level #%d]', 'pmpro-prorate' ), $this->original_level_id ) : $downgrading_from_level->name;
+		// Get the name of the level that is being downgraded to.
 		$downgrading_to_level = pmpro_getLevel( $this->new_level_id );
 		$downgrading_to_level_name = empty( $downgrading_to_level ) ? sprintf( __( '[deleted level #%d]', 'pmpro-prorate' ), $this->new_level_id ) : $downgrading_to_level->name;
 
@@ -433,13 +431,11 @@ class PMProrate_Downgrade {
 		// Generate the downgrade text and return.
 		if ( empty( $subscription_next_payment_date ) && empty( $expiration_date ) ) {
 			// If we don't have a next payment date for the subscription or an expiration date for the membership, then we don't know when the downgrade will be processed.
-			return sprintf( __( 'Your %s membership will be downgraded to %s.', 'pmpro-prorate' ), $downgrading_from_level_name, $downgrading_to_level_name );
-		} elseif ( empty( $expiration_date) || $subscription_next_payment_date < $expiration_date ) {
-			// If we don't have an expiration date or the next payment date is before the expiration date, then the downgrade will be processed on the next payment date.
-			return sprintf( __( 'Your %s membership will be downgraded to %s when your subscription renews on %s.', 'pmpro-prorate' ), $downgrading_from_level_name, $downgrading_to_level_name, date_i18n( get_option( 'date_format' ), $subscription_next_payment_date ) );
+			return sprintf( __( 'Downgrading to %s.', 'pmpro-prorate' ), $downgrading_to_level_name );
 		} else {
-			// If we have an expiration date and the next payment date is after the expiration date, then the downgrade will be processed on the expiration date.
-			return sprintf( __( 'Your %s membership will be downgraded to %s when it expires on %s.', 'pmpro-prorate' ), $downgrading_from_level_name, $downgrading_to_level_name, date_i18n( get_option( 'date_format' ), $expiration_date ) );
+			// We have a date for the downgrade. Use the earlier of the next payment date or the expiration date.
+			$downgrade_date = ( empty( $expiration_date) || $subscription_next_payment_date < $expiration_date ) ? $subscription->get_next_payment_date( 'date_format' ) : date_i18n( get_option( 'date_format' ), $expiration_date );
+			return sprintf( __( 'Downgrading to %s on %s.', 'pmpro-prorate' ), $downgrading_to_level_name, $downgrade_date );
 		}
 	}
 }

--- a/classes/pmprorate-class-downgrade.php
+++ b/classes/pmprorate-class-downgrade.php
@@ -434,7 +434,13 @@ class PMProrate_Downgrade {
 			return sprintf( __( 'Downgrading to %s.', 'pmpro-prorate' ), $downgrading_to_level_name );
 		} else {
 			// We have a date for the downgrade. Use the earlier of the next payment date or the expiration date.
-			$downgrade_date = ( empty( $expiration_date) || $subscription_next_payment_date < $expiration_date ) ? $subscription->get_next_payment_date( 'date_format' ) : date_i18n( get_option( 'date_format' ), $expiration_date );
+			if ( empty( $subscription_next_payment_date ) && ! empty( $expiration_date ) ) {
+				$downgrade_date = date_i18n( get_option( 'date_format' ), $expiration_date );
+			} elseif( ! empty( $subscription_next_payment_date ) && empty( $expiration_date ) ) {
+				$downgrade_date = $subscription->get_next_payment_date( 'date_format' );
+			} else {
+				$downgrade_date = ( $subscription_next_payment_date < $expiration_date ) ? $subscription->get_next_payment_date( 'date_format' ) : date_i18n( get_option( 'date_format' ), $expiration_date );
+			}
 			return sprintf( __( 'Downgrading to %s on %s.', 'pmpro-prorate' ), $downgrading_to_level_name, $downgrade_date );
 		}
 	}

--- a/classes/pmprorate-class-downgrade.php
+++ b/classes/pmprorate-class-downgrade.php
@@ -292,7 +292,7 @@ class PMProrate_Downgrade {
 			$data = array(
 				'display_name' => get_userdata( $this->user_id )->display_name,
 				'sitename' => get_bloginfo( 'name' ),
-				'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $this->user_id . '&pmpro_member_edit_panel=pmprorate_downgrades' ),
+				'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $this->user_id . '&pmpro_member_edit_panel=pmprorate-downgrades' ),
 			);
 			$email_admin = new PMProEmail();
 			$email_admin->template = 'delayed_downgrade_error_admin';
@@ -380,7 +380,7 @@ class PMProrate_Downgrade {
 			'display_name' => $user->display_name,
 			'sitename' => get_bloginfo( 'name' ),
 			'login_url' => wp_login_url(),
-			'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $user_id . '&pmpro_member_edit_panel=pmprorate_downgrades' ),
+			'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $user_id . '&pmpro_member_edit_panel=pmprorate-downgrades' ),
 		);
 
 		// Send email to user.

--- a/classes/pmprorate-class-member-edit-panel-downgrades.php
+++ b/classes/pmprorate-class-member-edit-panel-downgrades.php
@@ -5,7 +5,7 @@ class PMProrate_Member_Edit_Panel_Downgrades extends PMPro_Member_Edit_Panel {
 	 * Set up the panel.
 	 */
 	public function __construct() {
-		$this->slug = 'pmprorate_downgrades';
+		$this->slug = 'pmprorate-downgrades';
 		$this->title = __( 'Delayed Downgrades', 'pmpro-prorate' );
 	}
 

--- a/classes/pmprorate-class-member-edit-panel-downgrades.php
+++ b/classes/pmprorate-class-member-edit-panel-downgrades.php
@@ -1,0 +1,96 @@
+<?php
+
+class PMProrate_Member_Edit_Panel_Downgrades extends PMPro_Member_Edit_Panel {
+	/**
+	 * Set up the panel.
+	 */
+	public function __construct() {
+		$this->slug = 'pmprorate_downgrades';
+		$this->title = __( 'Delayed Downgrades', 'pmpro-prorate' );
+	}
+
+	/**
+	 * Display the panel contents.
+	 */
+	protected function display_panel_contents() {
+		// Get the user being edited.
+		$user = self::get_user();
+
+		// Get all downgrades for this user.
+		$downgrade_query_args = array(
+			'user_id' => $user->ID,
+		);
+		$downgrades = PMProrate_Downgrade::get_downgrades( $downgrade_query_args );
+
+		// If there are no downgrades, display a message and return.
+		if ( empty( $downgrades ) ) {
+			?>
+			<p><?php esc_html_e( 'There are no downgrades for this user.', 'pmpro-prorate' ); ?></p>
+			<?php
+			return;
+		}
+
+		// Display the downgrades in a table.
+		?>
+		<table class="wp-list-table widefat fixed striped">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'ID', 'pmpro-prorate' ); ?></th>
+					<th><?php esc_html_e( 'Downgrading From', 'pmpro-prorate' ); ?></th>
+					<th><?php esc_html_e( 'Downgrading To', 'pmpro-prorate' ); ?></th>
+					<th><?php esc_html_e( 'Order', 'pmpro-prorate' ); ?></th>
+					<th><?php esc_html_e( 'Status', 'pmpro-prorate' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php
+				foreach ( $downgrades as $downgrade ) {
+					// Get the level names to display.
+					$downgrading_from_level = pmpro_getLevel( $downgrade->original_level_id );
+					$downgrading_from_level_name = empty( $downgrading_from_level ) ? sprintf( __( '[deleted level #%d]', 'pmpro-prorate' ), $downgrade->original_level_id ) : $downgrading_from_level->name;
+					$downgrading_to_level = pmpro_getLevel( $downgrade->new_level_id );
+					$downgrading_to_level_name = empty( $downgrading_to_level ) ? sprintf( __( '[deleted level #%d]', 'pmpro-prorate' ), $downgrade->new_level_id ) : $downgrading_to_level->name;
+
+					// Get the order object and link.
+					$downgrade_order = new MemberOrder( $downgrade->downgrade_order_id );
+					$downgrade_order_link = add_query_arg( array( 'page' => 'pmpro-orders', 'order' => $downgrade->downgrade_order_id ), admin_url( 'admin.php' ) );
+
+					// Get the status text and class to show.
+					switch ( $downgrade->status ) {
+						case 'pending':
+							$status_text = $downgrade->get_downgrade_text();
+							$status_class = 'pmpro_tag pmpro_tag-has_icon pmpro_tag-alert';
+							break;
+						case 'downgraded_on_renewal':
+							$status_text = __( 'Processed on renewal', 'pmpro-prorate' );
+							$status_class = 'pmpro_tag pmpro_tag-has_icon pmpro_tag-success';
+							break;
+						case 'downgraded_on_expiration':
+							$status_text = __( 'Processed on expiration', 'pmpro-prorate' );
+							$status_class = 'pmpro_tag pmpro_tag-has_icon pmpro_tag-success';
+							break;
+						case 'lost_original_level':
+							$status_text = __( 'Lost original level', 'pmpro-prorate' );
+							$status_class = 'pmpro_tag pmpro_tag-has_icon pmpro_tag-error';
+							break;
+						case 'error':
+							$status_text = __( 'Error', 'pmpro-prorate' );
+							$status_class = 'pmpro_tag pmpro_tag-has_icon pmpro_tag-error';
+							break;
+					}
+					?>
+					<tr>
+						<td><?php echo esc_html( $downgrade->id ); ?></td>
+						<td><?php echo esc_html( $downgrading_from_level_name ); ?></td>
+						<td><?php echo esc_html( $downgrading_to_level_name ); ?></td>
+						<td><a href="<?php echo esc_url( $downgrade_order_link ); ?>"><?php echo esc_html( $downgrade_order->code ); ?></a></td>
+						<td><span class="pmpro_downgrade_status <?php echo esc_attr( $status_class ); ?>"><?php echo esc_html( $status_text ); ?></span></td>
+					</tr>
+					<?php
+				}
+				?>
+			</tbody>
+		</table>
+		<?php
+	}
+}

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -235,7 +235,7 @@ function pmprorate_pmpro_checkout_level( $level ) {
 		return $level;
 	}
 
-	// Get the number of days passed in the current payment period, the percentage of the period that has passed, and the percentage of the period that is left.
+	// Get the percentage of the period that is left.
 	$days_passed = ceil( ( $today - $last_payment_date ) / 3600 / 24 );
 	$per_passed = $days_passed / $days_in_period;        //as a % (decimal)
 	$per_left   = max( 1 - $per_passed, 0 );

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -91,7 +91,7 @@ function pmprorate_have_same_payment_period( $old, $new ) {
 		$corrected_old_level->cycle_period = $current_subscription[0]->get_cycle_period();
 
 		// Override $old_level with the corrected level so that we can use the same logic as PMPro v2.x.
-		$old_level = $corrected_old_level;
+		$old = $corrected_old_level;
 	}
 
 	$old_level = is_object( $old ) ? $old : pmpro_getLevel( $old );
@@ -129,7 +129,9 @@ function pmprorate_trim_timestamp($timestamp, $format = 'Y-m-d') {
 
 /**
  * Update the initial payment amount at checkout per prorating rules.
- * @todo : TODO MMPU: getLastMemberOrder and pmpro_next_payment need to check based on level.
+ *
+ * @param object $level The level that the user is purchasing.
+ * @return object
  */
 function pmprorate_pmpro_checkout_level( $level ) {	
 	global $current_user, $pmprorate_is_downgrade;
@@ -184,21 +186,48 @@ function pmprorate_pmpro_checkout_level( $level ) {
 		return $level;
 	}
 
-	// Get the last order.
-	$prev_order = new MemberOrder();
-	$prev_order->getLastMemberOrder( $current_user->ID, array( 'success', '', 'cancelled' ), $clevel_id );
+	// Getting the next payment date and most recent order has different logic for PMPro v2.x and v3.0+.
+	if ( class_exists( 'PMPro_Subscription' ) ) {
+		// Using PMPro v3.0+.
+		// Get the user's current subscription.
+		$current_subscription = PMPro_Subscription::get_subscriptions_for_user( get_current_user_id(), $clevel_id );
 
-	// No prorating needed if they don't have an order (were given the level by an admin/etc).
-	if ( empty( $prev_order->timestamp ) ) {
-		return $level;
+		// No prorating needed if they don't have a subscription.
+		if ( empty( $current_subscription ) ) {
+			return $level;
+		}
+
+		// Get the last payment date and next payment date.
+		$newest_orders = $current_subscription->get_orders( array( 'limit' => 1 ) );
+		if ( empty( $newest_orders ) ) {
+			return $level;
+		}
+
+		// Get the most recent order.
+		$prev_order = current( $newest_orders );
+
+		// Get the next payment date.
+		$next_payment_date = pmprorate_trim_timestamp( $current_subscription->get_next_payment_date() );
+	} else {
+		// Using PMPro v2.x.
+		// Get the last order.
+		$prev_order = new MemberOrder();
+		$prev_order->getLastMemberOrder( $current_user->ID, array( 'success', '', 'cancelled' ), $clevel_id );
+
+		// No prorating needed if they don't have an order (were given the level by an admin/etc).
+		if ( empty( $prev_order->timestamp ) ) {
+			return $level;
+		}
+
+		// Get the last payment date.
+		$next_payment_date = pmprorate_trim_timestamp( pmpro_next_payment( $current_user->ID ) );
 	}
 
-	// Get the last payment date, next payment date, and today.
+	// Get the most recent payment date and today's date.
 	$last_payment_date = pmprorate_trim_timestamp( $prev_order->timestamp );
-	$next_payment_date = pmprorate_trim_timestamp( pmpro_next_payment( $current_user->ID ) );
 	$today = pmprorate_trim_timestamp( current_time( 'timestamp' ) );
 
-	// Calculate the number of days in the current payment period.
+	// Calculate the total number of days in the current payment period.
 	$days_in_period = ceil( ( $next_payment_date - $last_payment_date ) / 3600 / 24 );
 
 	// If the next payment date is not after the last payment date, bail.
@@ -211,6 +240,10 @@ function pmprorate_pmpro_checkout_level( $level ) {
 	$per_passed = $days_passed / $days_in_period;        //as a % (decimal)
 	$per_left   = max( 1 - $per_passed, 0 );
 
+	// Get the credit for the remaining time on the old level.
+	$credit = $prev_order->subtotal * $per_left;
+
+	// If changing to a level with a different payment period, keep the "next payment date" the same.
 	if ( pmprorate_have_same_payment_period( $clevel, $level ) ) {
 		/*
 			Upgrade with same billing period in a nutshell:
@@ -219,7 +252,7 @@ function pmprorate_pmpro_checkout_level( $level ) {
 
 			Proration equation:
 			(a) What they should pay for new level = $level->billing_amount * $per_left.
-			(b) What they should have paid for current level = $clevel->billing_amount * $per_passed.
+			(b) What they should have paid for current payment period = $prev_order->subtotal * $per_passed.
 			What they need to pay = (a) + (b) - (what they already paid)
 			
 			If the number is negative, this would technically require a credit be given to the customer,
@@ -229,12 +262,11 @@ function pmprorate_pmpro_checkout_level( $level ) {
 			
 			An alternative calculation that comes up with the same number (but may be easier to understand) is:
 			(a) What they should pay for new level = $level->billing_amount * $per_left.
-			(b) Their credit for cancelling early = $clevel->billing_amount * $per_left.
+			(b) Their credit for cancelling early = $prev_order->subtotal * $per_left.
 			What they need to pay = (a) - (b)
 		*/
-		$new_level_cost = $level->billing_amount * $per_left;
-		$old_level_cost = $clevel->billing_amount * $per_passed;
-		$level->initial_payment = min( $level->initial_payment, round( $new_level_cost + $old_level_cost - $prev_order->subtotal, 2 ) );
+		$remaining_cost_for_new_level = $level->billing_amount * $per_left;
+		$level->initial_payment = min( $level->initial_payment, round( $remaining_cost_for_new_level - $credit, 2 ) );
 		
 		//make sure payment date stays the same
 		add_filter( 'pmpro_profile_start_date', 'pmprorate_set_startdate_to_next_payment_date', 10, 2 );			
@@ -244,7 +276,6 @@ function pmprorate_pmpro_checkout_level( $level ) {
 			1. Apply a credit to the initial payment based on the partial period of their old level.
 			2. New subscription starts today with the initial payment and will renew one period from now based on the new level.
 		*/
-		$credit                 = $prev_order->subtotal * $per_left;			
 		$level->initial_payment = round( $level->initial_payment - $credit, 2 );
 	}
 
@@ -253,52 +284,81 @@ function pmprorate_pmpro_checkout_level( $level ) {
 		$level->initial_payment = 0;
 	}
 
+	// Return the prorated level.
 	return $level;
 }
-
 add_filter( "pmpro_checkout_level", "pmprorate_pmpro_checkout_level", 10, 1 );
 
 /**
- * Set start date to the next payment date expected.
+ * Set the date that the first recurring payment will be charged.
+ *
+ * @param string $startdate The start date for the membership.
+ * @param object $order The order that is being purchased
  */
 function pmprorate_set_startdate_to_next_payment_date( $startdate, $order ) {
 	global $current_user;
-	
-	//use APIs to be more specific
-	if( $order->gateway == 'stripe' ) {
-		remove_filter('pmpro_next_payment', array('PMProGateway_stripe', 'pmpro_next_payment'), 10, 3);
-		add_filter('pmpro_next_payment', array('PMProGateway_stripe', 'pmpro_next_payment'), 10, 3);
-	} elseif( $order->gateway == 'paypalexpress' ) {
-		remove_filter('pmpro_next_payment', array('PMProGateway_paypalexpress', 'pmpro_next_payment'), 10, 3);
-		add_filter('pmpro_next_payment', array('PMProGateway_paypalexpress', 'pmpro_next_payment'), 10, 3);
-	}
-	
-	//TODO MMPU: Needs to get next payment for this level in particular
-	$next_payment_date = pmpro_next_payment( $current_user->ID );
+
+	// If using PMPro v2.x, we don't have the PMPro_Subscription class. Use old logic.
+	if ( ! class_exists( 'PMPro_Subscription' ) ) {
+		//use APIs to be more specific
+		if( $order->gateway == 'stripe' ) {
+			remove_filter('pmpro_next_payment', array('PMProGateway_stripe', 'pmpro_next_payment'), 10, 3);
+			add_filter('pmpro_next_payment', array('PMProGateway_stripe', 'pmpro_next_payment'), 10, 3);
+		} elseif( $order->gateway == 'paypalexpress' ) {
+			remove_filter('pmpro_next_payment', array('PMProGateway_paypalexpress', 'pmpro_next_payment'), 10, 3);
+			add_filter('pmpro_next_payment', array('PMProGateway_paypalexpress', 'pmpro_next_payment'), 10, 3);
+		}
 		
-	if( !empty( $next_payment_date ) )
-		$startdate = date( "Y-m-d", $next_payment_date ) . "T0:0:0";
+		// Note. This is not MMPU-compatible for PMPro v2.x.
+		$next_payment_date = pmpro_next_payment( $current_user->ID );
+			
+		if( !empty( $next_payment_date ) )
+			$startdate = date( "Y-m-d", $next_payment_date ) . "T0:0:0";
+		
+		return $startdate;
+	}
+
+	// Get the level ID that the user is switching from.
+	$clevel_id = pmproprorate_get_level_id_being_switched_from( $current_user->ID, $order->membership_id );
+
+	// Get the user's current subscription for that level.
+	$current_subscription = PMPro_Subscription::get_subscriptions_for_user( get_current_user_id(), $clevel_id );
+
+	// If the user doesn't have a subscription, bail. This shouldn't ever happen though since we check for this earlier.
+	if ( empty( $current_subscription ) ) {
+		return $startdate;
+	}
+
+	// Return the next payment date.
+	return $current_subscription->get_next_payment_date( 'Y-m-d H:i:s' );
 	
-	return $startdate;
 }
 
 /**
- * Keep your old startdate.
- * Updated from what's in paid-memberships-pro/includes/filters.php to run if the user has ANY level
+ * If the user is going to lose a level at checkout, have it keep the same start date.
+ * Updated from what's in paid-memberships-pro/includes/filters.php.
+ *
+ * @param string $startdate The start date for the membership.
+ * @param int $user_id The ID of the user.
+ * @param object $level The level that the user is purchasing.
  */
 function pmprorate_pmpro_checkout_start_date_keep_startdate( $startdate, $user_id, $level ) {
-	if ( pmpro_hasMembershipLevel() )  //<-- the line that was changed
-	{
+	// Check if the user is going to lose a level at checkout.
+	$old_level_id = pmproprorate_get_level_id_being_switched_from( $user_id, $level->id );
+	if ( ! empty( $old_level_id ) ) {
 		global $wpdb;
 
 		$sqlQuery = $wpdb->prepare( "
 			SELECT startdate 
 			FROM {$wpdb->pmpro_memberships_users} 
-			WHERE user_id = %d AND status = %s 
+			WHERE user_id = %d
+			AND status = %s 
+			AND membership_id = %d
 			ORDER BY id DESC 
 			LIMIT 1",
 			$user_id,
-			'active'
+			'active',
+			$old_level_id
 		);
 
 		$old_startdate = $wpdb->get_var( $sqlQuery );

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -76,6 +76,24 @@ function pmprorate_isDowngrade( $old, $new ) {
  *
  */
 function pmprorate_have_same_payment_period( $old, $new ) {
+	// If using PMPro v3.0+, $old_level should have data from the user's current subscription.
+	if ( class_exists( 'PMPro_Subscription' ) ) {
+		// Get the user's current subscription.
+		// If the user doesn't have a subscription, then the "payment period" is not the same.
+		$current_subscription = PMPro_Subscription::get_subscriptions_for_user( get_current_user_id(), $old->id );
+		if ( empty( $current_subscription ) ) {
+			return false;
+		}
+
+		$corrected_old_level = new stdClass();
+		$corrected_old_level->id           = $current_subscription[0]->get_membership_id();
+		$corrected_old_level->cycle_number = $current_subscription[0]->get_cycle_number();
+		$corrected_old_level->cycle_period = $current_subscription[0]->get_cycle_period();
+
+		// Override $old_level with the corrected level so that we can use the same logic as PMPro v2.x.
+		$old_level = $corrected_old_level;
+	}
+
 	$old_level = is_object( $old ) ? $old : pmpro_getLevel( $old );
 	$new_level = is_object( $new ) ? $new : pmpro_getLevel( $new );
 

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -20,6 +20,12 @@ function pmprorate_isDowngrade( $old, $new ) {
 		return false;
 	}
 
+	// Do not allow delayed downgrading if the new level is the same as the old level.
+	// Don't allow this to be filtered because the delayed downgrade flow won't handle this correctly.
+	if ( $old->id == $new->id ) {
+		return false;
+	}
+
 	// Check which PMPro version we are using.
 	if ( class_exists( 'PMPro_Subscription' ) ) {
 		// Using PMPro v3.0+.

--- a/includes/delayed-downgrades.php
+++ b/includes/delayed-downgrades.php
@@ -1,98 +1,429 @@
 <?php
 
 /**
- * Update confirmation message.
+ * Only run this downgrade code if using PMPro v3.0+.
+ *
+ * @since TBD
  */
-function pmprorate_pmpro_confirmation_message( $message, $invoice ) {
-	if ( ! empty( $invoice ) && ! empty( $invoice->user_id ) ) {
-		$downgrading = get_user_meta( $invoice->user_id, "pmpro_change_to_level", true );
+function pmprorate_init_downgrades() {
+	// Make sure that we are using PMPro v3.0+.
+	if ( ! class_exists( 'PMPro_Subscription' ) ) {
+		return;
+	}
 
-		if ( ! empty( $downgrading ) ) {
-			$dlevel = pmpro_getLevel( $downgrading['level'] );
+	// Hook functions to set up downgrades.
+	add_action( 'pmpro_added_order', 'pmprorate_added_order_mark_order_as_downgrade' ); // Running after order is created so that we can update metadata.
+	add_filter( 'pmpro_checkout_before_change_membership_level', 'pmprorate_checkout_before_change_membership_level_remember_downgrade', 20, 2 ); // Priority 20 to run after offsite payment gateway redirects.
 
-			$message .= "<p>";
-			$message .= esc_html(
-				sprintf(
-					__("You will be downgraded to %s on %s", "pmpro-proration"),
-				    $dlevel->name,
-				    date_i18n( get_option( "date_format" ), $downgrading['date'] )
-				)
-			);
-			$message .= "</p>";
+	// Hook functions to process downgrades.
+	add_action( 'pmpro_added_order', 'pmprorate_added_order_process_downgrade' ); // Running after the order is created so that the new order gets its membership ID changed to the new level.
+	add_action( 'pmpro_membership_pre_membership_expiry', 'pmprorate_membership_pre_membership_expiry', 10, 2 );
+
+	// Hook function to remove downgrade if the corresponding level is lost.
+	add_action( 'pmpro_after_all_membership_level_changes', 'pmprorate_after_all_membership_level_changes_check_downgrades' );
+
+	// Hook functions to show notices about downgrades.
+	add_action( 'pmpro_invoice_bullets_bottom', 'pmprorate_invoice_bullets_buttom_downgrades', 10, 1 );
+	add_filter( 'the_content', 'pmprorate_the_content_downgrades', 10, 1 );
+	add_filter( 'pmpro_member_edit_panels', 'pmprorate_member_edit_panels_downgrades', 10, 1 );
+
+}
+add_action( 'init', 'pmprorate_init_downgrades' );
+
+/**
+ * After an order is created, check the global $pmprorate_is_downgrade variable.
+ * If it is set, then mark the order as a downgrade to be scheduled later.
+ *
+ * @since TBD
+ *
+ * @param MemberOrder $order The order object.
+ */
+function pmprorate_added_order_mark_order_as_downgrade( $order ) {
+	global $pmprorate_is_downgrade;
+
+	// If we don't have an order, bail.
+	if ( empty( $order ) || empty( $order->id ) ) {
+		return;
+	}
+
+	// Update order meta.
+	if ( ! empty( $pmprorate_is_downgrade ) ) {
+		update_pmpro_membership_order_meta( $order->id, 'pmprorate_is_downgrade', $pmprorate_is_downgrade );
+	}
+}
+
+/**
+ * Bail from the checkout process when a user is downgrading. The downgrade will be completed asynchronously.
+ *
+ * @since TBD
+ *
+ * @param int $user_id The ID of the user.
+ * @param MemberOrder $order The order object.
+ */
+function pmprorate_checkout_before_change_membership_level_remember_downgrade( $user_id, $order ) {
+	global $wpdb, $pmpro_level, $pmprorate_is_downgrade;
+
+	// If we don't have an order, then this checkout is free. Create a free order.
+	if ( empty( $order ) ) {
+		// Get the user's email address.
+		$bemail = $wpdb->get_var( $wpdb->prepare( "SELECT user_email FROM $wpdb->users WHERE ID = %d LIMIT 1", $user_id ) );
+
+		// Create a free order. Taken from core checkout preheader code.
+		$order                 = new MemberOrder();
+		$order->InitialPayment = 0;
+		$order->Email          = $bemail;
+		$order->gateway        = 'free';
+		$order->status         = 'success';
+		$order = apply_filters( "pmpro_checkout_order_free", $order );
+		$order->user_id       = $user_id;
+		$order->membership_id = $pmpro_level->id;
+	}
+
+	// If this order was not marked as a downgrade, bail.
+	// $pmprorate_is_downgrade checks if the checkout started processing on this page load.
+	// Checking order meta checks if the checkout started processing on a previous page load, such as with offsite payment gateways.
+	if ( empty( get_pmpro_membership_order_meta( $order->id, 'pmprorate_is_downgrade', true ) ) && empty( $pmprorate_is_downgrade) ) {
+		return;
+	}
+
+	// If we already have a downgrade scheduled for this order, bail.
+	$downgrade_query_args = array(
+		'downgrade_order_id' => $order->id,
+	);
+	if ( ! empty( PMProrate_Downgrade::get_downgrades( $downgrade_query_args ) ) ) {
+		return;
+	}
+
+	// We need to sechedule the downgrade.
+	// Get the level that the user is downgrading from.
+	$downgrading_from_id = pmproprorate_get_level_id_being_switched_from( $user_id, $order->membership_id );
+	if ( empty( $downgrading_from_id ) ) {
+		// If we can't determine the level that the user is downgrading from, bail and let PMPro handle the checkout normally.
+		return;
+	}
+
+	// Get the user's subscriptions for the old level.
+	$old_subscriptions = PMPro_Subscription::get_subscriptions_for_user( $user_id, $downgrading_from_id );
+	if ( ! empty( $old_subscriptions ) ) {
+		// If the level being purchased will not have a subscription, set the expiration date for the
+		// user's current membership to the next payment date of their current subscription.
+		// This is so that we know when to downgrade the membership without an active subscription.
+		if ( empty( (float)$pmpro_level->billing_amount) ) {
+			// Get the next payment date for the user's current subscription.
+			$next_payment_date = $old_subscriptions[0]->get_next_payment_date( 'Y-m-d H:i:s' );
+			$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->pmpro_memberships_users SET enddate = %s WHERE user_id = %d AND membership_id = %d AND status = 'active'", $next_payment_date, $user_id, $downgrading_from_id ) );
+		}
+
+		// Cancel the user's subscriptions for the old level.
+		foreach ( $old_subscriptions as $subscription_to_cancel ) {
+			$subscription_to_cancel->cancel_at_gateway();
 		}
 	}
 
-	return $message;
+	// Update the order's membership level ID to the level that the user is downgrading from.
+	$order->membership_id = $downgrading_from_id;
+	$order->user_id = $user_id;
+	$order->status  = 'success';
+	$order->saveOrder();
+
+	// Save the data collected at checkout to the order.
+	pmpro_save_checkout_data_to_order( $order );
+
+	// Update the subscription's membership level ID to the level that the user is downgrading from.
+	$subscription = $order->get_subscription();
+	if ( ! empty( $subscription ) ) {
+		$subscription->set( 'membership_level_id', $downgrading_from_id );
+		$subscription->save();
+	}
+
+	// Create the downgrade.
+	$downgrade = PMProrate_Downgrade::create( $user_id, $downgrading_from_id, $pmpro_level->id, $order->id );
+	if ( empty( $downgrade ) ) {
+		// Creating the downgrade failed. Bail and let PMPro handle the checkout normally.
+		return;
+	}
+
+	// Prepare emails stating that their membership will be downgraded.
+	$user = get_userdata( $user_id );
+	$data = array(
+		'display_name' => $user->display_name,
+		'sitename' => get_bloginfo( 'name' ),
+		'login_url' => wp_login_url(),
+		'pmprorate_downgrade_text' => $downgrade->get_downgrade_text(),
+		'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $user_id . '&pmpro_member_edit_panel=pmprorate_downgrades' ),
+	);
+
+	// Send email to user.
+	$data['header_name'] = $user->display_name;
+	$email = new PMProEmail();
+	$email->template = 'delayed_downgrade_scheduled';
+	$email->email = $user->user_email;
+	$email->data = $data;
+	$email->sendEmail();
+
+	// Send email to the site admin.
+	unset( $data['header_name'] );
+	$email_admin = new PMProEmail();
+	$email_admin->template = 'delayed_downgrade_scheduled_admin';
+	$email_admin->email = get_bloginfo( 'admin_email' );
+	$email_admin->data = $data;
+	$email_admin->sendEmail();
+
+	// Redirect to the invoice page instead of changing the user's level and completing the checkout process.
+	wp_redirect( add_query_arg( 'invoice', $order->code, pmpro_url( 'invoice' ) ) );
+	exit;
 }
 
-add_filter( "pmpro_confirmation_message", "pmprorate_pmpro_confirmation_message", 10, 2 );
+/**
+ * Add downgrade information to the invoice page.
+ *
+ * @since TBD
+ *
+ * @param MemberOrder $order The order object being shown.
+ */
+function pmprorate_invoice_bullets_buttom_downgrades( $order ) {
+	// Check if this order is associated with a pending downgrade.
+	$downgrade_query_args = array(
+		'downgrade_order_id' => $order->id,
+		'status' => 'pending',
+	);
+	$downgrades = PMProrate_Downgrade::get_downgrades( $downgrade_query_args );
+
+	// If we don't have any downgrades, bail.
+	if ( empty( $downgrades ) ) {
+		return;
+	}
+
+	// Get the downgrade text.
+	$downgrade_text = $downgrades[0]->get_downgrade_text();
+	if ( empty( $downgrade_text ) ) {
+		return;
+	}
+
+	// Show the downgrade text.
+	echo '<li>' . esc_html( $downgrade_text ) . '</li>';
+}
 
 /**
- * Update account page.
+ * Add downgrade information to the account page.
+ *
+ * @since TBD
+ *
+ * @param string $content The content of the current page.
+ * @return string The content of the current page.
  */
-function pmprorate_the_content( $content ) {
+function pmprorate_the_content_downgrades( $content ) {
 	global $current_user, $pmpro_pages;
 
-	if ( is_user_logged_in() && is_page( $pmpro_pages['account'] ) ) {
-		$downgrading = get_user_meta( $current_user->ID, "pmpro_change_to_level", true );
+	// If the user is not logged in, bail.
+	if ( empty( $current_user ) || empty( $current_user->ID ) ) {
+		return $content;
+	}
 
-		if ( ! empty( $downgrading ) ) {
-			$downgrade_level = pmpro_getLevel( $downgrading['level'] );
+	// If the user is not on the account page, bail.
+	if ( empty( $pmpro_pages['account'] ) || ! is_page( $pmpro_pages['account'] ) ) {
+		return $content;
+	}
 
-			$downgrade_message = "<p><strong>" . esc_html__( "Important Note:", "pmpro-proration" ) . "</strong>";
-			$downgrade_message .= esc_html(
-				sprintf(
-					__( "You will be downgraded to %s on %s.", "pmpro-proration" ),
-					$downgrade_level->name,
-					date_i18n( get_option( "date_format" ), $downgrading['date'] )
-				)
-			);
+	// Get the user's pending downgrades.
+	$downgrade_query_args = array(
+		'user_id' => $current_user->ID,
+		'status' => 'pending',
+	);
+	$downgrades = PMProrate_Downgrade::get_downgrades( $downgrade_query_args );
 
-			$content = $downgrade_message . $content;
+	// Show a downgrade notice for each pending downgrade.
+	foreach ( $downgrades as $downgrade ) {
+		// Get the downgrade text.
+		$downgrade_text = $downgrade->get_downgrade_text();
+		if ( empty( $downgrade_text ) ) {
+			continue;
 		}
+
+		// Show the downgrade text.
+		$content = '<p><strong>' . esc_html__( 'Important Note:', 'pmpro-proration' ) . '</strong> ' . esc_html( $downgrade_text ) . '</p>' . $content;
 	}
 
 	return $content;
 }
 
-add_filter( "the_content", "pmprorate_the_content" );
+/**
+ * Add a panel to the Edit Member dashboard page.
+ *
+ * @since TBD
+ *
+ * @param array $panels Array of panels.
+ * @return array
+ */
+function pmprorate_member_edit_panels_downgrades( $panels ) {
+	// If the class doesn't exist and the abstract class does, require the class.
+	if ( ! class_exists( 'PMProup_Member_Edit_Panel' ) && class_exists( 'PMPro_Member_Edit_Panel' ) ) {
+		require_once( PMPRORATE_DIR . '/classes/pmprorate-class-member-edit-panel-downgrades.php' );
+	}
+
+	// If the class exists, add a panel.
+	if ( class_exists( 'PMProrate_Member_Edit_Panel_Downgrades' ) ) {
+		$panels[] = new PMProrate_Member_Edit_Panel_Downgrades();
+	}
+
+	return $panels;
+}
 
 /**
- * Check for level changes daily.
+ * When an order is created, check if is a part of a subscription.
+ * If so, check if the subscription has a downgrade order linked.
+ * If so, process the downgrade.
+ *
+ * @since TBD
+ *
+ * @param MemberOrder $order The order object.
  */
-function pmproproate_daily_check_for_membership_changes() {
-	global $wpdb;
-
-	//make sure we only run once a day
-	$today = date( "Y-m-d", current_time( 'timestamp' ) );
-
-	//get all users with scheduled level changes
-	$level_changes = $wpdb->get_col( "SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = 'pmpro_change_to_level'" );
-
-	if ( empty( $level_changes ) ) {
+ function pmprorate_added_order_process_downgrade( $order ) {
+	// Get the subscription for this order.
+	$subscription = $order->get_subscription();
+	if ( empty( $subscription ) ) {
+		// If this order is not for a subscription, bail.
 		return;
 	}
 
-	foreach ( $level_changes as $user_id ) {
-		//today?
-		$change = get_user_meta( $user_id, 'pmpro_change_to_level', true );
+	// Get all pending downgrades for this user and the order's membership level.
+	$downgrade_query_args = array(
+		'user_id' => $order->user_id,
+		'original_level_id' => $order->membership_id,
+		'status' => 'pending',
+	);
+	$downgrades = PMProrate_Downgrade::get_downgrades( $downgrade_query_args );
 
-		if ( ! empty( $change ) && ! empty( $change['date'] ) && ! empty( $change['level'] ) && $change['date'] <= $today ) {
-			//get user's current level
-			$clevel = pmpro_getMembershipLevelForUser( $user_id );
+	// If we don't have any downgrades, bail.
+	if ( empty( $downgrades ) ) {
+		return;
+	}
 
-			//change back
-			if ( ! empty( $clevel ) ) {
-
-				$wpdb->update( $wpdb->pmpro_memberships_users, array( 'membership_id' => $change['level'] ), array( 'membership_id' => $clevel->id, 'user_id' => $user_id, 'status' => 'active') );
-
-			}
-
-			//delete user meta
-			delete_user_meta( $user_id, 'pmpro_change_to_level' );
+	// For each downgrade, check if $order is part of the same subscription as the downgrade's order.
+	$downgrade_processed = false;
+	foreach ( $downgrades as $downgrade ) {
+		// If we have already processed a downgrade for this order, then we should not process another.
+		if ( $downgrade_processed ) {
+			$downgrade->update_status( 'error' );
+			continue;
 		}
+
+		// Get the order for this downgrade.
+		$downgrade_order = MemberOrder::get_order( $downgrade->downgrade_order_id );
+		if ( empty( $downgrade_order ) ) {
+			// If we can't get the order for this downgrade, bail.
+			$downgrade->update_status( 'error' );
+			continue;
+		}
+
+		// Get the subscription for this order.
+		$downgrade_subscription = $downgrade_order->get_subscription();
+		if ( empty( $downgrade_subscription ) ) {
+			// If this order is not for a subscription, bail.
+			$downgrade->update_status( 'error' );
+			continue;
+		}
+
+		// If the subscription for this downgrade is not the same as the subscription for the order, bail.
+		if ( $subscription->get_id() !== $downgrade_subscription->get_id() ) {
+			$downgrade->update_status( 'error' );
+			continue;
+		}
+
+		// If we get here, then we have a downgrade for this order. Process it.
+		$downgrade_processed = $downgrade->process( $order );
 	}
 }
 
-//hook to run when pmpro_cron_expire_memberships does
-add_action( 'pmpro_cron_expire_memberships', 'pmproproate_daily_check_for_membership_changes' );
+/**
+ * When a membership is about to expire, check if it is part of a downgrade.
+ * If so, process the downgrade.
+ *
+ * @since TBD
+ *
+ * @param int $user_id The ID of the user having a level expired.
+ * @param int $level_id The ID of the level being expired.
+ */
+function pmprorate_membership_pre_membership_expiry( $user_id, $level_id ) {
+	// Check if the user has a pending downgrade for this level.
+	$downgrade_query_args = array(
+		'user_id' => $user_id,
+		'original_level_id' => $level_id,
+		'status' => 'pending',
+	);
+	$downgrades = PMProrate_Downgrade::get_downgrades( $downgrade_query_args );
+	if ( empty( $downgrades ) ) {
+		// If the user does not have a pending downgrade for this level, bail.
+		return;
+	}
+
+	// For each downgrade, try to process it. We should only have one downgrade, so once we process one, mark the rest as errors.
+	$downgrade_processed = false;
+	foreach ( $downgrades as $downgrade ) {
+		// If we have already processed a downgrade for this level, then we should not process another.
+		if ( $downgrade_processed ) {
+			$downgrade->update_status( 'error' );
+			continue;
+		}
+
+		// Process the downgrade.
+		$downgrade_processed = $downgrade->process();
+	}
+
+	// Now that their level is downgraded, it should not be expired, but we still want to skip the expiration email.
+	add_action( 'pmpro_send_expiration_email', 'pmprorate_send_expiration_email' );
+}
+
+/**
+ * Skip the next expiration email.
+ *
+ * @since TBD
+ *
+ * @param bool $skip Whether to skip the expiration email.
+ * @return bool Whether to skip the expiration email.
+ */
+ function pmprorate_send_expiration_email( $skip ) {
+	// Unhook this function so that it doesn't run for future expirations.
+	remove_action( 'pmpro_send_expiration_email', 'pmprorate_send_expiration_email' );
+
+	// Skip the expiration email.
+	return false;
+ }
+
+/**
+ * When a user loses a level, check if they have a pending downgrade for that level.
+ * If so, remove the downgrade.
+ *
+ * @since TBD
+ *
+ * @param array $old_user_levels The old levels the users had.
+ */
+function pmprorate_after_all_membership_level_changes_check_downgrades( $old_user_levels ) {
+	// Loop through all users who have had changed levels.
+	foreach ( $old_user_levels as $user_id => $old_levels ) {
+		// Get the IDs of the user's old levels.
+		$old_level_ids = wp_list_pluck( $old_levels, 'id' );
+
+		// Get the new level for this user.
+		$new_levels    = pmpro_getMembershipLevelsForUser( $user_id );
+		$new_level_ids = wp_list_pluck( $new_levels, 'id' );
+
+		// Get the levels that the user lost.
+		$lost_level_ids = array_diff( $old_level_ids, $new_level_ids );
+
+		// Check if the lost level IDs have any pending downgrades.
+		foreach ( $lost_level_ids as $lost_level_id ) {
+			$downgrade_query_args = array(
+				'user_id' => $user_id,
+				'original_level_id' => $lost_level_id,
+				'status' => 'pending',
+			);
+			$downgrades = PMProrate_Downgrade::get_downgrades( $downgrade_query_args );
+
+			// Mark any pending downgrades as lost_original_level.
+			foreach ( $downgrades as $downgrade ) {
+				$downgrade->update_status( 'lost_original_level' );
+			}
+		}
+	}
+}

--- a/includes/delayed-downgrades.php
+++ b/includes/delayed-downgrades.php
@@ -150,7 +150,7 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 		'sitename' => get_bloginfo( 'name' ),
 		'login_url' => wp_login_url(),
 		'pmprorate_downgrade_text' => $downgrade->get_downgrade_text(),
-		'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $user_id . '&pmpro_member_edit_panel=pmprorate_downgrades' ),
+		'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $user_id . '&pmpro_member_edit_panel=pmprorate-downgrades' ),
 	);
 
 	// Send email to user.

--- a/includes/delayed-downgrades.php
+++ b/includes/delayed-downgrades.php
@@ -24,8 +24,7 @@ function pmprorate_init_downgrades() {
 
 	// Hook functions to show notices about downgrades.
 	add_action( 'pmpro_invoice_bullets_bottom', 'pmprorate_invoice_bullets_buttom_downgrades', 10, 1 );
-	add_filter( 'pmpro_account_membership_expiration_text', 'pmprorate_account_membership_expiration_text_downgrades', 10, 2 );
-	add_filter( 'pmpro_member_edit_memberships_panel_memberships_enddate_text', 'pmprorate_member_edit_memberships_panel_memberships_enddate_text_downgrades', 10, 3 );
+	add_filter( 'pmpro_membership_expiration_text', 'pmprorate_membership_expiration_text_downgrades', 10, 3 );
 	add_filter( 'pmpro_member_edit_panels', 'pmprorate_member_edit_panels_downgrades', 10, 1 );
 
 }
@@ -212,44 +211,15 @@ function pmprorate_invoice_bullets_buttom_downgrades( $order ) {
  *
  * @param string $expiration_text The expiration text.
  * @param object $level The level object.
- */
-function pmprorate_account_membership_expiration_text_downgrades( $expiration_text, $level ) {
-	global $current_user;
-
-	// If the user is not logged in, bail.
-	if ( empty( $current_user ) || empty( $current_user->ID ) ) {
-		return $expiration_text;
-	}
-
-	// Avoid duplicate logic by calling pmprorate_member_edit_memberships_panel_memberships_enddate_text_downgrades().
-	$downgrade_text = pmprorate_member_edit_memberships_panel_memberships_enddate_text_downgrades( null, $current_user, $level );
-
-	// Add <p> tags if needed.
-	if ( ! empty( $downgrade_text ) ) {
-		$expiration_text = '<p>' . $downgrade_text . '</p>';
-	}
-
-	return $expiration_text;
-}
-
-/**
- * Filter the expiration date text to show to the administrator.
- *
- * @since TBD
- *
- * @param string $enddate_text The expiration date text to show for this level.
  * @param WP_User $user The user object.
- * @param object $shown_level The level object.
+ *
+ * @return string
  */
-function pmprorate_member_edit_memberships_panel_memberships_enddate_text_downgrades( $enddate_text, $user, $shown_level ) {
-	if ( empty( $user ) || empty( $user->ID ) ) {
-		return $enddate_text;
-	}
-
+function pmprorate_membership_expiration_text_downgrades( $expiration_text, $level, $user ) {
 	// Get the user's pending downgrades for this level.
 	$downgrade_query_args = array(
 		'user_id' => $user->ID,
-		'original_level_id' => $shown_level->id,
+		'original_level_id' => $level->id,
 		'status' => 'pending',
 	);
 	$downgrades = PMProrate_Downgrade::get_downgrades( $downgrade_query_args );
@@ -258,15 +228,14 @@ function pmprorate_member_edit_memberships_panel_memberships_enddate_text_downgr
 	foreach ( $downgrades as $downgrade ) {
 		// Get the downgrade text.
 		$downgrade_text = $downgrade->get_downgrade_text();
-		if ( empty( $downgrade_text ) ) {
-			continue;
+		if ( ! empty( $downgrade_text ) ) {
+			// Show the downgrade text.
+			$expiration_text = $downgrade_text;
+			break;
 		}
-
-		// Show the downgrade text.
-		$enddate_text = $downgrade_text;
 	}
 
-	return $enddate_text;
+	return $expiration_text;
 }
 
 /**

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -137,3 +137,146 @@ function pmprorate_pmpro_isOrderRecurring( $order, $test_checkout = false ) {
 	//must be recurring
 	return true;
 }
+
+/**
+ * Function to set up legacy downgrades for PMPro versions before 3.0.
+ *
+ * @since TBD
+ *
+ * @param object $clevel The user's current level that is being downgraded from.
+ */
+function pmprorate_legacy_downgrade_set_up( $clevel ) {
+	global $pmpro_checkout_old_level, $current_user;
+	$pmpro_checkout_old_level = $clevel;
+	$pmpro_checkout_old_level->next_payment = pmprorate_trim_timestamp( pmpro_next_payment( $current_user->ID ) );
+}
+
+/**
+ * After checkout, if the user downgraded, then revert to the old level and remember to change them to the new level later.
+ */
+function pmprorate_pmpro_after_checkout( $user_id ) {
+	global $pmpro_checkout_old_level, $wpdb;
+
+	// If using PMPro v3.0+, bail since we have a better downgrade process for 3.0+.
+	if ( class_exists( 'PMPro_Subscription' ) ) {
+		return;
+	}
+
+	if ( ! empty( $pmpro_checkout_old_level ) && ! empty( $pmpro_checkout_old_level->next_payment ) ) {
+		$new_level = pmpro_getMembershipLevelForUser( $user_id );
+
+		//remember to update to this level later
+		update_user_meta( $user_id, "pmpro_change_to_level", array( "date"  => $pmpro_checkout_old_level->next_payment,
+		                                                            "level" => $new_level->id
+		) );
+
+		//change their membership level
+		if ( false === $wpdb->update(
+				$wpdb->pmpro_memberships_users,
+				array( 'membership_id' => $pmpro_checkout_old_level->id ),
+				array( 'membership_id' => $new_level->id, 'user_id' => $user_id, 'status' => 'active' )
+			)
+		) {
+			pmpro_setMessage( esc_html__( 'Problem updating membership information. Please report this to the webmaster.', 'pmpro-proration' ), 'error' );
+		};
+	} else {
+		delete_user_meta( $user_id, "pmpro_change_to_level" );
+	}
+}
+add_filter( 'pmpro_after_checkout', 'pmprorate_pmpro_after_checkout' );
+
+/**
+ * Update confirmation message.
+ */
+function pmprorate_pmpro_confirmation_message( $message, $invoice ) {
+	if ( ! empty( $invoice ) && ! empty( $invoice->user_id ) ) {
+		$downgrading = get_user_meta( $invoice->user_id, "pmpro_change_to_level", true );
+
+		if ( ! empty( $downgrading ) ) {
+			$dlevel = pmpro_getLevel( $downgrading['level'] );
+
+			$message .= "<p>";
+			$message .= esc_html(
+				sprintf(
+					__("You will be downgraded to %s on %s", "pmpro-proration"),
+				    $dlevel->name,
+				    date_i18n( get_option( "date_format" ), $downgrading['date'] )
+				)
+			);
+			$message .= "</p>";
+		}
+	}
+
+	return $message;
+}
+
+add_filter( "pmpro_confirmation_message", "pmprorate_pmpro_confirmation_message", 10, 2 );
+
+/**
+ * Update account page.
+ */
+function pmprorate_the_content( $content ) {
+	global $current_user, $pmpro_pages;
+
+	if ( is_user_logged_in() && is_page( $pmpro_pages['account'] ) ) {
+		$downgrading = get_user_meta( $current_user->ID, "pmpro_change_to_level", true );
+
+		if ( ! empty( $downgrading ) ) {
+			$downgrade_level = pmpro_getLevel( $downgrading['level'] );
+
+			$downgrade_message = "<p><strong>" . esc_html__( "Important Note:", "pmpro-proration" ) . "</strong>";
+			$downgrade_message .= esc_html(
+				sprintf(
+					__( "You will be downgraded to %s on %s.", "pmpro-proration" ),
+					$downgrade_level->name,
+					date_i18n( get_option( "date_format" ), $downgrading['date'] )
+				)
+			);
+
+			$content = $downgrade_message . $content;
+		}
+	}
+
+	return $content;
+}
+add_filter( "the_content", "pmprorate_the_content" );
+
+/**
+ * Check for level changes daily.
+ */
+function pmproproate_daily_check_for_membership_changes() {
+	global $wpdb;
+
+	//make sure we only run once a day
+	$today = date( "Y-m-d", current_time( 'timestamp' ) );
+
+	//get all users with scheduled level changes
+	$level_changes = $wpdb->get_col( "SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = 'pmpro_change_to_level'" );
+
+	if ( empty( $level_changes ) ) {
+		return;
+	}
+
+	foreach ( $level_changes as $user_id ) {
+		//today?
+		$change = get_user_meta( $user_id, 'pmpro_change_to_level', true );
+
+		if ( ! empty( $change ) && ! empty( $change['date'] ) && ! empty( $change['level'] ) && $change['date'] <= $today ) {
+			//get user's current level
+			$clevel_id = pmproprorate_get_level_id_being_switched_from( $user_id, $change['level'] );
+
+			//change back
+			if ( ! empty( $clevel_id ) ) {
+
+				$wpdb->update( $wpdb->pmpro_memberships_users, array( 'membership_id' => $change['level'] ), array( 'membership_id' => $clevel_id, 'user_id' => $user_id, 'status' => 'active') );
+
+			}
+
+			//delete user meta
+			delete_user_meta( $user_id, 'pmpro_change_to_level' );
+		}
+	}
+}
+
+//hook to run when pmpro_cron_expire_memberships does
+add_action( 'pmpro_cron_expire_memberships', 'pmproproate_daily_check_for_membership_changes' );

--- a/includes/emails.php
+++ b/includes/emails.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Add proration-specific templates to the email templates.
+ *
+ * @since TBD
+ *
+ * @param array $templates that can be edited.
+ * @return array $templates that can be edited.
+ */
+function pmprorate_template_callback( $templates ) {
+	$templates['delayed_downgrade_scheduled'] = array(
+		'subject' => esc_html( sprintf( __( 'Your downgrade has been scheduled at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) ),
+		'description' => __( 'Proration Downgrade Scheduled', 'pmpro-prorate' ),
+		'body' => pmprorate_get_default_delayed_downgrade_scheduled_email_body(),
+		'help_text' => __( 'This email is sent when a membership downgrade is scheduled. The !!pmprorate_downgrade_text!! placeholder variable can be used to display the details of the downgrade.', 'pmpro-prorate' ),
+	);
+	$templates['delayed_downgrade_scheduled_admin'] = array(
+        'subject' => esc_html( sprintf( __( 'A downgrade has been scheduled at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) ),
+        'description' => __( 'Proration Downgrade Scheduled (Admin)', 'pmpro-prorate' ),
+        'body' => pmprorate_get_default_delayed_downgrade_scheduled_admin_email_body(),
+        'help_text' => __( 'This email is sent when a membership downgrade is scheduled. The !!edit_member_downgrade_url!! placeholder variable can be used to show a link to the downgrades list.', 'pmpro-prorate' ),
+    );
+    $templates['delayed_downgrade_processed'] = array(
+        'subject' => esc_html( sprintf( __( 'Your downgrade has been processed at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) ),
+        'description' => __( 'Proration Downgrade Processed', 'pmpro-prorate' ),
+        'body' => pmprorate_get_default_delayed_downgrade_processed_email_body(),
+        'help_text' => __( 'This email is sent when a membership downgrade is processed.', 'pmpro-prorate' ),
+    );
+    $templates['delayed_downgrade_processed_admin'] = array(
+        'subject' => esc_html( sprintf( __( 'A downgrade has been processed at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) ),
+        'description' => __( 'Proration Downgrade Processed (Admin)', 'pmpro-prorate' ),
+        'body' => pmprorate_get_default_delayed_downgrade_processed_admin_email_body(),
+        'help_text' => __( 'This email is sent when a membership downgrade is processed. The !!edit_member_downgrade_url!! placeholder variable can be used to show a link to the downgrades list.', 'pmpro-prorate' ),
+    );
+    $templates['delayed_downgrade_error_admin'] = array(
+        'subject' => esc_html( sprintf( __( 'There was an error processing a downgrade at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) ),
+        'description' => __( 'Proration Downgrade Error (Admin)', 'pmpro-prorate' ),
+        'body' => pmprorate_get_default_delayed_downgrade_error_admin_email_body(),
+        'help_text' => __( 'This email is sent when there is an error processing a membership downgrade. The !!edit_member_downgrade_url!! placeholder variable can be used to show a link to the downgrades list.', 'pmpro-prorate' ),
+    );
+	
+	return $templates;
+}
+add_filter( 'pmproet_templates', 'pmprorate_template_callback');
+
+/**
+ * Default email content for the delayed_downgrade_scheduled email template.
+ *
+ * @since TBD
+ *
+ * @return string
+ */
+function pmprorate_get_default_delayed_downgrade_scheduled_email_body() {
+	ob_start();
+    ?>
+    <p>!!pmprorate_downgrade_text!!</p>
+    <p><?php esc_html_e( 'Log in to view your account here: !!login_url!!', 'pmpro-prorate' ); ?></p>
+    <?php
+	$body = ob_get_contents();
+	ob_end_clean();
+	return $body;
+}
+
+/**
+ * Default email content for the delayed_downgrade_scheduled_admin email template.
+ *
+ * @since TBD
+ *
+ * @return string
+ */
+function pmprorate_get_default_delayed_downgrade_scheduled_admin_email_body() {
+    ob_start();
+    ?>
+    <p><?php esc_html_e( 'A downgrade for !!display_name!! has been scheduled at !!sitename!!.'); ?></p>
+    <p><?php esc_html_e( "View the user's downgrade information here: !!edit_member_downgrade_url!!", 'pmpro-prorate' ); ?></p>
+    <?php
+    $body = ob_get_contents();
+    ob_end_clean();
+    return $body;
+}
+
+/**
+ * Default email content for the delayed_downgrade_processed email template.
+ *
+ * @since TBD
+ *
+ * @return string
+ */
+function pmprorate_get_default_delayed_downgrade_processed_email_body() {
+    ob_start();
+    ?>
+    <p><?php esc_html_e( 'Your downgrade has been successfully processed.', 'pmpro-prorate' ); ?></p>
+    <p><?php esc_html_e( 'Log in to view your account here: !!login_url!!', 'pmpro-prorate' ); ?></p>
+    <?php
+    $body = ob_get_contents();
+    ob_end_clean();
+    return $body;
+}
+
+/**
+ * Default email content for the delayed_downgrade_processed_admin email template.
+ *
+ * @since TBD
+ *
+ * @return string
+ */
+function pmprorate_get_default_delayed_downgrade_processed_admin_email_body() {
+    ob_start();
+    ?>
+    <p><?php esc_html_e( 'A downgrade for !!display_name!! has been successfully processed at !!sitename!!.'); ?></p>
+    <p><?php esc_html_e( "View the user's downgrade information here: !!edit_member_downgrade_url!!", 'pmpro-prorate' ); ?></p>
+    <?php
+    $body = ob_get_contents();
+    ob_end_clean();
+    return $body;
+}
+
+/**
+ * Default email content for the delayed_downgrade_error_admin email template.
+ *
+ * @since TBD
+ *
+ * @return string
+ */
+function pmprorate_get_default_delayed_downgrade_error_admin_email_body() {
+    ob_start();
+    ?>
+    <p><?php esc_html_e( 'There was an error processing a downgrade for !!display_name!! at !!sitename!!.'); ?></p>
+    <p><?php esc_html_e( "View the user's downgrade information here: !!edit_member_downgrade_url!!", 'pmpro-prorate' ); ?></p>
+    <?php
+    $body = ob_get_contents();
+    ob_end_clean();
+    return $body;
+}

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -42,7 +42,7 @@ function pmprorate_db_delta() {
 			`original_level_id` int(11) unsigned NOT NULL,
             `new_level_id` int(11) unsigned NOT NULL,
             `downgrade_order_id` bigint(20) unsigned NOT NULL,
-			`status` enum('pending','downgraded_on_renewal','downgraded_on_expiration','lost_original_level','error') NOT NULL DEFAULT 'pending',
+			`status` varchar(32) NOT NULL DEFAULT 'pending',
 			PRIMARY KEY (`id`),
 			KEY `user_id` (`user_id`),
             KEY `downgrade_order_id` (`downgrade_order_id`)

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Run any necessary upgrades to the DB.
+ *
+ * @since TBD
+ */
+function pmprorate_check_for_upgrades() {
+	$db_version = get_option( 'pmprorate_db_version' );
+
+	// If we can't find the DB tables, reset db_version to 0
+	global $wpdb;
+	$wpdb->hide_errors();
+	$wpdb->pmprorate_downgrades = $wpdb->prefix . 'pmprorate_downgrades';
+	$table_exists = $wpdb->query("SHOW TABLES LIKE '" . $wpdb->pmprorate_downgrades . "'");
+	if(!$table_exists)
+		$db_version = 0;
+
+	// Default options.
+	if ( ! $db_version ) {
+		pmprorate_db_delta();
+		update_option( 'pmprorate_db_version', 1 );
+	}
+}
+
+/**
+ * Make sure the DB is set up correctly.
+ *
+ * @since TBD
+ */
+function pmprorate_db_delta() {
+	require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
+
+	global $wpdb;
+	$wpdb->hide_errors();
+	$wpdb->pmprorate_downgrades = $wpdb->prefix . 'pmprorate_downgrades';
+
+	// pmprorate_downgrades
+    $sqlQuery = "
+		CREATE TABLE `" . $wpdb->pmprorate_downgrades . "` (
+			`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			`user_id` bigint(20) unsigned NOT NULL,
+			`original_level_id` int(11) unsigned NOT NULL,
+            `new_level_id` int(11) unsigned NOT NULL,
+            `downgrade_order_id` bigint(20) unsigned NOT NULL,
+			`status` enum('pending','downgraded_on_renewal','downgraded_on_expiration','lost_original_level','error') NOT NULL DEFAULT 'pending',
+			PRIMARY KEY (`id`),
+			KEY `user_id` (`user_id`),
+            KEY `downgrade_order_id` (`downgrade_order_id`)
+		);
+	";
+	dbDelta( $sqlQuery );
+}
+
+// Check if the DB needs to be upgraded.
+if ( is_admin() || defined('WP_CLI') ) {
+	pmprorate_check_for_upgrades();
+}

--- a/pmpro-proration.php
+++ b/pmpro-proration.php
@@ -30,15 +30,6 @@ global $wpdb;
 $wpdb->pmprorate_downgrades = $wpdb->prefix . 'pmprorate_downgrades';
 
 /**
- * Mark the plugin as MMPU-incompatible.
- */
-  function pmproprorate_mmpu_incompatible_add_ons( $incompatible ) {
-	$incompatible[] = 'PMPro Prorations Add On';
-	return $incompatible;
-}
-add_filter( 'pmpro_mmpu_incompatible_add_ons', 'pmproprorate_mmpu_incompatible_add_ons' );
-
-/**
  * Add links to the plugin row meta
  */
 function pmproproate_plugin_row_meta( $links, $file ) {

--- a/pmpro-proration.php
+++ b/pmpro-proration.php
@@ -8,6 +8,8 @@ Author: Stranger Studios
 Author URI: http://www.strangerstudios.com
 */
 
+define( 'PMPRORATE_DIR', dirname( __FILE__ ) );
+
 /**
  * Load the languages folder for translations.
  */
@@ -16,9 +18,16 @@ function pmprorate_load_plugin_text_domain() {
 }
 add_action( 'plugins_loaded', 'pmprorate_load_plugin_text_domain' );
 
-include_once( plugin_dir_path( __FILE__ ) . 'includes/checkout.php' ); // Handles proration at checkout
-include_once( plugin_dir_path( __FILE__ ) . 'includes/delayed-downgrades.php' ); // Handles downgrade UI and processing delayed downgrades.
-include_once( plugin_dir_path( __FILE__ ) . 'includes/deprecated.php' ); // Deprecated functions.
+include_once( PMPRORATE_DIR . '/classes/pmprorate-class-downgrade.php' ); // Handles downgrades.
+include_once( PMPRORATE_DIR . '/includes/checkout.php' ); // Handles proration at checkout
+include_once( PMPRORATE_DIR . '/includes/delayed-downgrades.php' ); // Handles downgrade UI and processing delayed downgrades.
+include_once( PMPRORATE_DIR . '/includes/emails.php' ); // Handles emails.
+include_once( PMPRORATE_DIR . '/includes/upgradecheck.php' ); // Checks for upgrades.
+include_once( PMPRORATE_DIR . '/includes/deprecated.php' ); // Deprecated functions.
+
+// Set up $wpdb tables.
+global $wpdb;
+$wpdb->pmprorate_downgrades = $wpdb->prefix . 'pmprorate_downgrades';
 
 /**
  * Mark the plugin as MMPU-incompatible.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-lock-membership-level/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-lock-membership-level/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
(Note, this new delayed downgrade behavior only runs when PMPro v3.0+ is active)
- For 3.0+, only allows for prorations within the same "one level per group" membership group
- Adds a new table to track delayed downgrades along with a corresponding PHP class
- Instead of processing a delayed downgrade via a cron, processes when a recurring order is received or the old membership expires
- Processes an entire asynchronous checkout instead of just swapping level IDs in the database
- Includes a view for admins to see past and upcoming delayed downgrades for a user
- Sends proration emails to users and admins when a delayed downgrade is scheduled and another email when the downgrade is processed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
