### PR TITLE
Fix missing User ID in Proration Downgrade Processed admin email

### DIFF
--- a/classes/pmprorate-class-downgrade.php
+++ b/classes/pmprorate-class-downgrade.php
@@ -380,7 +380,7 @@ class PMProrate_Downgrade {
 			'display_name' => $user->display_name,
 			'sitename' => get_bloginfo( 'name' ),
 			'login_url' => wp_login_url(),
-			'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $user_id . '&pmpro_member_edit_panel=pmprorate-downgrades' ),
+			'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $this->user_id . '&pmpro_member_edit_panel=pmprorate-downgrades' ),
 		);
 
 		// Send email to user.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-proration/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-proration/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes missing User ID in the Proration Downgrade Processed admin email's downgrade URLs 

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
