### PR TITLE
Avoiding setting filters during pmpro_checkout_level

### DIFF
--- a/includes/delayed-downgrades.php
+++ b/includes/delayed-downgrades.php
@@ -46,9 +46,14 @@ function pmprorate_added_order_mark_order_as_downgrade( $order ) {
 		return;
 	}
 
+	// Get the level for this order.
+	$level = $order->getMembershipLevelAtCheckout();
+
 	// Update order meta.
-	if ( ! empty( $pmprorate_is_downgrade ) ) {
+	if ( ! empty( $pmprorate_is_downgrade ) ) { // This will only ever be set before PMPro v3.4.
 		update_pmpro_membership_order_meta( $order->id, 'pmprorate_is_downgrade', $pmprorate_is_downgrade );
+	} elseif( ! empty( $level->pmprorate_is_downgrade ) ) { // This will only ever be set after PMPro v3.4.
+		update_pmpro_membership_order_meta( $order->id, 'pmprorate_is_downgrade', $level->pmprorate_is_downgrade );
 	}
 }
 
@@ -79,10 +84,13 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 		$order->membership_id = $pmpro_level->id;
 	}
 
+	// Get the level for the order.
+	$level = $order->getMembershipLevelAtCheckout();
+
 	// If this order was not marked as a downgrade, bail.
 	// $pmprorate_is_downgrade checks if the checkout started processing on this page load.
 	// Checking order meta checks if the checkout started processing on a previous page load, such as with offsite payment gateways.
-	if ( empty( get_pmpro_membership_order_meta( $order->id, 'pmprorate_is_downgrade', true ) ) && empty( $pmprorate_is_downgrade) ) {
+	if ( empty( get_pmpro_membership_order_meta( $order->id, 'pmprorate_is_downgrade', true ) ) && empty( $pmprorate_is_downgrade ) && empty( $level->pmprorate_is_downgrade ) ) {
 		return;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-proration/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-proration/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Prevents conflicts that arise when `pmpro_getLevelAtCheckout()` is called for levels other than the level being purchased during a checkout page load. See #28 for more details.

Resolves #28

Relies on https://github.com/strangerstudios/paid-memberships-pro/pull/3233

Once that core PR is merged, this PR should be updated to use the corresponding PMPro version in case that version is not PMPro v3.4.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
