### PR TITLE
Fix text-domain for localized strings

### DIFF
--- a/classes/pmprorate-class-downgrade.php
+++ b/classes/pmprorate-class-downgrade.php
@@ -410,7 +410,7 @@ class PMProrate_Downgrade {
 	public function get_downgrade_text() {
 		// Get the name of the level that is being downgraded to.
 		$downgrading_to_level = pmpro_getLevel( $this->new_level_id );
-		$downgrading_to_level_name = empty( $downgrading_to_level ) ? sprintf( esc_html__( '[deleted level #%d]', 'pmpro-prorate' ), $this->new_level_id ) : $downgrading_to_level->name;
+		$downgrading_to_level_name = empty( $downgrading_to_level ) ? sprintf( esc_html__( '[deleted level #%d]', 'pmpro-proration' ), $this->new_level_id ) : $downgrading_to_level->name;
 
 		// Get the order for this downgrade.
 		$order = MemberOrder::get_order( $this->downgrade_order_id );
@@ -431,7 +431,7 @@ class PMProrate_Downgrade {
 		// Generate the downgrade text and return.
 		if ( empty( $subscription_next_payment_date ) && empty( $expiration_date ) ) {
 			// If we don't have a next payment date for the subscription or an expiration date for the membership, then we don't know when the downgrade will be processed.
-			return sprintf( esc_html__( 'Downgrading to %s.', 'pmpro-prorate' ), $downgrading_to_level_name );
+			return sprintf( esc_html__( 'Downgrading to %s.', 'pmpro-proration' ), $downgrading_to_level_name );
 		} else {
 			// We have a date for the downgrade. Use the earlier of the next payment date or the expiration date.
 			if ( empty( $subscription_next_payment_date ) && ! empty( $expiration_date ) ) {
@@ -441,7 +441,7 @@ class PMProrate_Downgrade {
 			} else {
 				$downgrade_date = ( $subscription_next_payment_date < $expiration_date ) ? $subscription->get_next_payment_date( 'date_format' ) : date_i18n( get_option( 'date_format' ), $expiration_date );
 			}
-			return sprintf( esc_html__( 'Downgrading to %s on %s.', 'pmpro-prorate' ), $downgrading_to_level_name, $downgrade_date );
+			return sprintf( esc_html__( 'Downgrading to %s on %s.', 'pmpro-proration' ), $downgrading_to_level_name, $downgrade_date );
 		}
 	}
 }

--- a/classes/pmprorate-class-member-edit-panel-downgrades.php
+++ b/classes/pmprorate-class-member-edit-panel-downgrades.php
@@ -6,7 +6,7 @@ class PMProrate_Member_Edit_Panel_Downgrades extends PMPro_Member_Edit_Panel {
 	 */
 	public function __construct() {
 		$this->slug = 'pmprorate-downgrades';
-		$this->title = esc_html__( 'Delayed Downgrades', 'pmpro-prorate' );
+		$this->title = esc_html__( 'Delayed Downgrades', 'pmpro-proration' );
 	}
 
 	/**
@@ -25,7 +25,7 @@ class PMProrate_Member_Edit_Panel_Downgrades extends PMPro_Member_Edit_Panel {
 		// If there are no downgrades, display a message and return.
 		if ( empty( $downgrades ) ) {
 			?>
-			<p><?php esc_html_e( 'There are no downgrades for this user.', 'pmpro-prorate' ); ?></p>
+			<p><?php esc_html_e( 'There are no downgrades for this user.', 'pmpro-proration' ); ?></p>
 			<?php
 			return;
 		}
@@ -35,11 +35,11 @@ class PMProrate_Member_Edit_Panel_Downgrades extends PMPro_Member_Edit_Panel {
 		<table class="wp-list-table widefat fixed striped">
 			<thead>
 				<tr>
-					<th><?php esc_html_e( 'ID', 'pmpro-prorate' ); ?></th>
-					<th><?php esc_html_e( 'Downgrading From', 'pmpro-prorate' ); ?></th>
-					<th><?php esc_html_e( 'Downgrading To', 'pmpro-prorate' ); ?></th>
-					<th><?php esc_html_e( 'Order', 'pmpro-prorate' ); ?></th>
-					<th><?php esc_html_e( 'Status', 'pmpro-prorate' ); ?></th>
+					<th><?php esc_html_e( 'ID', 'pmpro-proration' ); ?></th>
+					<th><?php esc_html_e( 'Downgrading From', 'pmpro-proration' ); ?></th>
+					<th><?php esc_html_e( 'Downgrading To', 'pmpro-proration' ); ?></th>
+					<th><?php esc_html_e( 'Order', 'pmpro-proration' ); ?></th>
+					<th><?php esc_html_e( 'Status', 'pmpro-proration' ); ?></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -47,9 +47,9 @@ class PMProrate_Member_Edit_Panel_Downgrades extends PMPro_Member_Edit_Panel {
 				foreach ( $downgrades as $downgrade ) {
 					// Get the level names to display.
 					$downgrading_from_level = pmpro_getLevel( $downgrade->original_level_id );
-					$downgrading_from_level_name = empty( $downgrading_from_level ) ? sprintf( esc_html__( '[deleted level #%d]', 'pmpro-prorate' ), $downgrade->original_level_id ) : $downgrading_from_level->name;
+					$downgrading_from_level_name = empty( $downgrading_from_level ) ? sprintf( esc_html__( '[deleted level #%d]', 'pmpro-proration' ), $downgrade->original_level_id ) : $downgrading_from_level->name;
 					$downgrading_to_level = pmpro_getLevel( $downgrade->new_level_id );
-					$downgrading_to_level_name = empty( $downgrading_to_level ) ? sprintf( esc_html__( '[deleted level #%d]', 'pmpro-prorate' ), $downgrade->new_level_id ) : $downgrading_to_level->name;
+					$downgrading_to_level_name = empty( $downgrading_to_level ) ? sprintf( esc_html__( '[deleted level #%d]', 'pmpro-proration' ), $downgrade->new_level_id ) : $downgrading_to_level->name;
 
 					// Get the order object and link.
 					$downgrade_order = new MemberOrder( $downgrade->downgrade_order_id );
@@ -62,19 +62,19 @@ class PMProrate_Member_Edit_Panel_Downgrades extends PMPro_Member_Edit_Panel {
 							$status_class = 'pmpro_tag pmpro_tag-has_icon pmpro_tag-alert';
 							break;
 						case 'downgraded_on_renewal':
-							$status_text = esc_html__( 'Processed on renewal', 'pmpro-prorate' );
+							$status_text = esc_html__( 'Processed on renewal', 'pmpro-proration' );
 							$status_class = 'pmpro_tag pmpro_tag-has_icon pmpro_tag-success';
 							break;
 						case 'downgraded_on_expiration':
-							$status_text = esc_html__( 'Processed on expiration', 'pmpro-prorate' );
+							$status_text = esc_html__( 'Processed on expiration', 'pmpro-proration' );
 							$status_class = 'pmpro_tag pmpro_tag-has_icon pmpro_tag-success';
 							break;
 						case 'lost_original_level':
-							$status_text = esc_html__( 'Lost original level', 'pmpro-prorate' );
+							$status_text = esc_html__( 'Lost original level', 'pmpro-proration' );
 							$status_class = 'pmpro_tag pmpro_tag-has_icon pmpro_tag-error';
 							break;
 						case 'error':
-							$status_text = esc_html__( 'Error', 'pmpro-prorate' );
+							$status_text = esc_html__( 'Error', 'pmpro-proration' );
 							$status_class = 'pmpro_tag pmpro_tag-has_icon pmpro_tag-error';
 							break;
 					}

--- a/includes/emails.php
+++ b/includes/emails.php
@@ -9,34 +9,34 @@
  */
 function pmprorate_template_callback( $templates ) {
 	$templates['delayed_downgrade_scheduled'] = array(
-		'subject' => esc_html( sprintf( __( 'Your downgrade has been scheduled at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) ),
-		'description' => esc_html__( 'Proration Downgrade Scheduled', 'pmpro-prorate' ),
+		'subject' => esc_html( sprintf( __( 'Your downgrade has been scheduled at %s', 'pmpro-proration' ), get_option( 'blogname' ) ) ),
+		'description' => esc_html__( 'Proration Downgrade Scheduled', 'pmpro-proration' ),
 		'body' => pmprorate_get_default_delayed_downgrade_scheduled_email_body(),
-		'help_text' => esc_html__( 'This email is sent when a membership downgrade is scheduled. The !!pmprorate_downgrade_text!! placeholder variable can be used to display the details of the downgrade.', 'pmpro-prorate' ),
+		'help_text' => esc_html__( 'This email is sent when a membership downgrade is scheduled. The !!pmprorate_downgrade_text!! placeholder variable can be used to display the details of the downgrade.', 'pmpro-proration' ),
 	);
 	$templates['delayed_downgrade_scheduled_admin'] = array(
-        'subject' => esc_html( sprintf( __( 'A downgrade has been scheduled at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) ),
-        'description' => esc_html__( 'Proration Downgrade Scheduled (Admin)', 'pmpro-prorate' ),
+        'subject' => esc_html( sprintf( __( 'A downgrade has been scheduled at %s', 'pmpro-proration' ), get_option( 'blogname' ) ) ),
+        'description' => esc_html__( 'Proration Downgrade Scheduled (Admin)', 'pmpro-proration' ),
         'body' => pmprorate_get_default_delayed_downgrade_scheduled_admin_email_body(),
-        'help_text' => esc_html__( 'This email is sent when a membership downgrade is scheduled. The !!edit_member_downgrade_url!! placeholder variable can be used to show a link to the downgrades list.', 'pmpro-prorate' ),
+        'help_text' => esc_html__( 'This email is sent when a membership downgrade is scheduled. The !!edit_member_downgrade_url!! placeholder variable can be used to show a link to the downgrades list.', 'pmpro-proration' ),
     );
     $templates['delayed_downgrade_processed'] = array(
-        'subject' => esc_html( sprintf( __( 'Your downgrade has been processed at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) ),
-        'description' => esc_html__( 'Proration Downgrade Processed', 'pmpro-prorate' ),
+        'subject' => esc_html( sprintf( __( 'Your downgrade has been processed at %s', 'pmpro-proration' ), get_option( 'blogname' ) ) ),
+        'description' => esc_html__( 'Proration Downgrade Processed', 'pmpro-proration' ),
         'body' => pmprorate_get_default_delayed_downgrade_processed_email_body(),
-        'help_text' => esc_html__( 'This email is sent when a membership downgrade is processed.', 'pmpro-prorate' ),
+        'help_text' => esc_html__( 'This email is sent when a membership downgrade is processed.', 'pmpro-proration' ),
     );
     $templates['delayed_downgrade_processed_admin'] = array(
-        'subject' => esc_html( sprintf( __( 'A downgrade has been processed at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) ),
-        'description' => esc_html__( 'Proration Downgrade Processed (Admin)', 'pmpro-prorate' ),
+        'subject' => esc_html( sprintf( __( 'A downgrade has been processed at %s', 'pmpro-proration' ), get_option( 'blogname' ) ) ),
+        'description' => esc_html__( 'Proration Downgrade Processed (Admin)', 'pmpro-proration' ),
         'body' => pmprorate_get_default_delayed_downgrade_processed_admin_email_body(),
-        'help_text' => esc_html__( 'This email is sent when a membership downgrade is processed. The !!edit_member_downgrade_url!! placeholder variable can be used to show a link to the downgrades list.', 'pmpro-prorate' ),
+        'help_text' => esc_html__( 'This email is sent when a membership downgrade is processed. The !!edit_member_downgrade_url!! placeholder variable can be used to show a link to the downgrades list.', 'pmpro-proration' ),
     );
     $templates['delayed_downgrade_error_admin'] = array(
-        'subject' => esc_html( sprintf( __( 'There was an error processing a downgrade at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) ),
-        'description' => esc_html__( 'Proration Downgrade Error (Admin)', 'pmpro-prorate' ),
+        'subject' => esc_html( sprintf( __( 'There was an error processing a downgrade at %s', 'pmpro-proration' ), get_option( 'blogname' ) ) ),
+        'description' => esc_html__( 'Proration Downgrade Error (Admin)', 'pmpro-proration' ),
         'body' => pmprorate_get_default_delayed_downgrade_error_admin_email_body(),
-        'help_text' => esc_html__( 'This email is sent when there is an error processing a membership downgrade. The !!edit_member_downgrade_url!! placeholder variable can be used to show a link to the downgrades list.', 'pmpro-prorate' ),
+        'help_text' => esc_html__( 'This email is sent when there is an error processing a membership downgrade. The !!edit_member_downgrade_url!! placeholder variable can be used to show a link to the downgrades list.', 'pmpro-proration' ),
     );
 	
 	return $templates;
@@ -54,7 +54,7 @@ function pmprorate_get_default_delayed_downgrade_scheduled_email_body() {
 	ob_start();
     ?>
     <p>!!pmprorate_downgrade_text!!</p>
-    <p><?php esc_html_e( 'Log in to view your account here: !!login_url!!', 'pmpro-prorate' ); ?></p>
+    <p><?php esc_html_e( 'Log in to view your account here: !!login_url!!', 'pmpro-proration' ); ?></p>
     <?php
 	$body = ob_get_contents();
 	ob_end_clean();
@@ -72,7 +72,7 @@ function pmprorate_get_default_delayed_downgrade_scheduled_admin_email_body() {
     ob_start();
     ?>
     <p><?php esc_html_e( 'A downgrade for !!display_name!! has been scheduled at !!sitename!!.'); ?></p>
-    <p><?php esc_html_e( "View the user's downgrade information here: !!edit_member_downgrade_url!!", 'pmpro-prorate' ); ?></p>
+    <p><?php esc_html_e( "View the user's downgrade information here: !!edit_member_downgrade_url!!", 'pmpro-proration' ); ?></p>
     <?php
     $body = ob_get_contents();
     ob_end_clean();
@@ -89,8 +89,8 @@ function pmprorate_get_default_delayed_downgrade_scheduled_admin_email_body() {
 function pmprorate_get_default_delayed_downgrade_processed_email_body() {
     ob_start();
     ?>
-    <p><?php esc_html_e( 'Your downgrade has been successfully processed.', 'pmpro-prorate' ); ?></p>
-    <p><?php esc_html_e( 'Log in to view your account here: !!login_url!!', 'pmpro-prorate' ); ?></p>
+    <p><?php esc_html_e( 'Your downgrade has been successfully processed.', 'pmpro-proration' ); ?></p>
+    <p><?php esc_html_e( 'Log in to view your account here: !!login_url!!', 'pmpro-proration' ); ?></p>
     <?php
     $body = ob_get_contents();
     ob_end_clean();
@@ -108,7 +108,7 @@ function pmprorate_get_default_delayed_downgrade_processed_admin_email_body() {
     ob_start();
     ?>
     <p><?php esc_html_e( 'A downgrade for !!display_name!! has been successfully processed at !!sitename!!.'); ?></p>
-    <p><?php esc_html_e( "View the user's downgrade information here: !!edit_member_downgrade_url!!", 'pmpro-prorate' ); ?></p>
+    <p><?php esc_html_e( "View the user's downgrade information here: !!edit_member_downgrade_url!!", 'pmpro-proration' ); ?></p>
     <?php
     $body = ob_get_contents();
     ob_end_clean();
@@ -126,7 +126,7 @@ function pmprorate_get_default_delayed_downgrade_error_admin_email_body() {
     ob_start();
     ?>
     <p><?php esc_html_e( 'There was an error processing a downgrade for !!display_name!! at !!sitename!!.'); ?></p>
-    <p><?php esc_html_e( "View the user's downgrade information here: !!edit_member_downgrade_url!!", 'pmpro-prorate' ); ?></p>
+    <p><?php esc_html_e( "View the user's downgrade information here: !!edit_member_downgrade_url!!", 'pmpro-proration' ); ?></p>
     <?php
     $body = ob_get_contents();
     ob_end_clean();

--- a/pmpro-proration.php
+++ b/pmpro-proration.php
@@ -1,11 +1,13 @@
 <?php
 /*
-Plugin Name: Paid Memberships Pro - Proration Add On
-Plugin URI: http://www.paidmembershipspro.com/wp/pmpro-proration/
-Description: Simple proration for membership level upgrades and downgrades.
-Version: 1.0
-Author: Paid Memberships Pro
-Author URI: https://www.paidmembershipspro.com
+ * Plugin Name: Paid Memberships Pro - Proration Add On
+ * Plugin URI: http://www.paidmembershipspro.com/wp/pmpro-proration/
+ * Description: Simple proration for membership level upgrades and downgrades.
+ * Version: 1.0
+ * Author: Paid Memberships Pro
+ * Author URI: https://www.paidmembershipspro.com
+ * Text Domain: pmpro-proration
+ * Domain Path: /languages
 */
 
 define( 'PMPRORATE_DIR', dirname( __FILE__ ) );


### PR DESCRIPTION
* BUG FIX: Fixed an issue for localized strings using the incorrect text-domain.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-proration/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-proration/pulls/) for the same update/change?