### PR TITLE
[ENHANCEMENT] Overhaul email templates

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php
@@ -1,0 +1,170 @@
+<?php
+
+class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro_Email_Template {
+
+	/**
+	 * The parent user.
+	 *
+	 * @var WP_User
+	 */
+	protected $user;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_User $user The user downgrading.
+	 */
+	public function __construct( WP_User $user ) {
+		$this->user = $user;
+	}
+
+	/**
+	 * Get the email template slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email template slug.
+	 */
+	public static function get_template_slug() {
+		return 'delayed_downgrade_error_admin';
+	}
+
+	/**
+	 * Get the "nice name" of the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "nice name" of the email template.
+	 */
+	public static function get_template_name() {
+		return esc_html__( 'Proration Downgrade Error (Admin)', 'pmpro-prorate' );
+	}
+
+	/**
+	 * Get "help text" to display to the admin when editing the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "help text" to display to the admin when editing the email template.
+	 */
+	public static function get_template_description() {
+		return esc_html__( 'This email is sent t the admin when there is an error processing a membership downgrade.', 'pmpro-prorate' );
+	}
+
+	/**
+	 * Get the default subject for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default subject for the email.
+	 */
+	public static function get_default_subject() {
+		return esc_html__( sprintf( __( 'There was an error processing a downgrade at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) );
+	}
+
+	/**
+	 * Get the default body content for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default body content for the email.
+	 */
+	public static function get_default_body() {
+		return wp_kses_post( __( pmprorate_get_default_delayed_downgrade_error_admin_email_body() ) );
+	}
+
+	/**
+	 * Get the email template variables for the email paired with a description of the variable.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public static function get_email_template_variables_with_description() {
+	
+		return array(
+			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+			'!!edit_member_downgrade_url!!' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
+		);
+	}
+
+	/**
+	 * Get the email template variables for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public function get_email_template_variables() {
+		$user = $this->user;
+		$email_template_variables = array(	
+			'display_name' => $user->display_name,
+			'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $user->ID . '&pmpro_member_edit_panel=pmprorate-downgrades' ),
+		);
+		return $email_template_variables;
+	}
+
+	/**
+	 * Get the email address to send the email to.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email address to send the email to.
+	 */
+	public function get_recipient_email() {
+		//send to the admin
+		return get_bloginfo( 'admin_email' );
+	}
+
+	/**
+	 * Get the name of the email recipient.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The name of the email recipient.
+	 */
+	public function get_recipient_name() {
+		$user = get_user_by( 'email', $this->get_recipient_email() );
+		return empty( $user->display_name ) ? esc_html__( 'Admin', 'pmpro-proration' ) : $user->display_name;
+	}
+
+	/**
+	 * Send a test email.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $email The email address to send the test email to.
+	 * @return bool Whether the email was sent successfully.
+	 */
+	public static function send_test( $email ) {
+		global $current_user;
+
+		//Instantiate this class with mock data to get access to the non-static methods
+		$test_checkout_check_template = new PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin( $current_user );
+
+		$test_email = new PMProEmail();
+		$test_email->email = $email;
+		$test_email->subject  =  self::get_default_subject();
+		// Add test mail text to the default body
+		$test_email->body = pmpro_email_templates_test_body( self::get_default_body() );
+		$test_email->data = array_merge( $test_checkout_check_template->get_base_email_template_variables(),
+			$test_checkout_check_template->get_email_template_variables() );
+		$test_email->template = self::get_template_slug();
+		return $test_email->sendEmail();
+	}
+}
+/**
+ * Register the email template.
+ *
+ * @since TBD
+ *
+ * @param array $email_templates The email templates (template slug => email template class name)
+ * @return array The modified email templates array.
+ */
+function pmpro_email_template_pmpro_proration_delayed_downgrade_error_admin( $email_templates ) {
+	$email_templates['delayed_downgrade_error_admin'] = 'PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin';
+	return $email_templates;
+}
+add_filter( 'pmpro_email_templates', 'pmpro_email_template_pmpro_proration_delayed_downgrade_error_admin' );

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php
@@ -39,7 +39,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	 * @return string The "nice name" of the email template.
 	 */
 	public static function get_template_name() {
-		return esc_html__( 'Proration Downgrade Error (Admin)', 'pmpro-prorate' );
+		return esc_html__( 'Proration Downgrade Error (Admin)', 'pmpro-prorations' );
 	}
 
 	/**
@@ -50,7 +50,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	 * @return string The "help text" to display to the admin when editing the email template.
 	 */
 	public static function get_template_description() {
-		return esc_html__( 'This email is sent to the admin when there is an error processing a membership downgrade.', 'pmpro-prorate' );
+		return esc_html__( 'This email is sent to the admin when there is an error processing a membership downgrade.', 'pmpro-prorations' );
 	}
 
 	/**
@@ -61,7 +61,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	 * @return string The default subject for the email.
 	 */
 	public static function get_default_subject() {
-		return esc_html( sprintf( __( 'There was an error processing a downgrade at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) );
+		return esc_html( sprintf( __( 'There was an error processing a downgrade at %s', 'pmpro-prorations' ), get_option( 'blogname' ) ) );
 	}
 
 	/**
@@ -139,10 +139,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	 */
 	public static function get_test_email_constructor_args() {
 		global $current_user;
-
-		//Create test downgrade.
-		$test_downgrade = PMProrate_Downgrade::get_test_downgrade();
-		return array( $current_user, $test_downgrade );
+		return array( $current_user );
 	}
 }
 /**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php
@@ -39,7 +39,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	 * @return string The "nice name" of the email template.
 	 */
 	public static function get_template_name() {
-		return esc_html__( 'Proration Downgrade Error (Admin)', 'pmpro-prorations' );
+		return esc_html__( 'Proration Downgrade Error (Admin)', 'pmpro-proration' );
 	}
 
 	/**
@@ -50,7 +50,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	 * @return string The "help text" to display to the admin when editing the email template.
 	 */
 	public static function get_template_description() {
-		return esc_html__( 'This email is sent to the admin when there is an error processing a membership downgrade.', 'pmpro-prorations' );
+		return esc_html__( 'This email is sent to the admin when there is an error processing a membership downgrade.', 'pmpro-proration' );
 	}
 
 	/**
@@ -61,7 +61,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	 * @return string The default subject for the email.
 	 */
 	public static function get_default_subject() {
-		return esc_html( sprintf( __( 'There was an error processing a downgrade at %s', 'pmpro-prorations' ), get_option( 'blogname' ) ) );
+		return esc_html( sprintf( __( 'There was an error processing a downgrade at %s', 'pmpro-proration' ), get_option( 'blogname' ) ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php
@@ -50,7 +50,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	 * @return string The "help text" to display to the admin when editing the email template.
 	 */
 	public static function get_template_description() {
-		return esc_html__( 'This email is sent t the admin when there is an error processing a membership downgrade.', 'pmpro-prorate' );
+		return esc_html__( 'This email is sent to the admin when there is an error processing a membership downgrade.', 'pmpro-prorate' );
 	}
 
 	/**
@@ -61,7 +61,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	 * @return string The default subject for the email.
 	 */
 	public static function get_default_subject() {
-		return esc_html__( sprintf( __( 'There was an error processing a downgrade at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) );
+		return esc_html( sprintf( __( 'There was an error processing a downgrade at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) );
 	}
 
 	/**
@@ -72,7 +72,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( __( pmprorate_get_default_delayed_downgrade_error_admin_email_body() ) );
+		return wp_kses_post( pmprorate_get_default_delayed_downgrade_error_admin_email_body() );
 	}
 
 	/**
@@ -131,28 +131,18 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	}
 
 	/**
-	 * Send a test email.
+	 * Returns the arguments to send the test email from the abstract class.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $email The email address to send the test email to.
-	 * @return bool Whether the email was sent successfully.
+	 * @return array The arguments to send the test email from the abstract class.
 	 */
-	public static function send_test( $email ) {
+	public static function get_test_email_constructor_args() {
 		global $current_user;
 
-		//Instantiate this class with mock data to get access to the non-static methods
-		$test_checkout_check_template = new PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin( $current_user );
-
-		$test_email = new PMProEmail();
-		$test_email->email = $email;
-		$test_email->subject  =  self::get_default_subject();
-		// Add test mail text to the default body
-		$test_email->body = pmpro_email_templates_test_body( self::get_default_body() );
-		$test_email->data = array_merge( $test_checkout_check_template->get_base_email_template_variables(),
-			$test_checkout_check_template->get_email_template_variables() );
-		$test_email->template = self::get_template_slug();
-		return $test_email->sendEmail();
+		//Create test downgrade.
+		$test_downgrade = PMProrate_Downgrade::get_test_downgrade();
+		return array( $current_user, $test_downgrade );
 	}
 }
 /**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed-admin.php
@@ -1,0 +1,172 @@
+<?php
+
+class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed_Admin extends PMPro_Email_Template {
+
+	/**
+	 * The parent user.
+	 *
+	 * @var WP_User
+	 */
+	protected $user;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_User $user The user downgrading.
+	 * @param PMProrate_Downgrade $downgrade The downgrade object.
+	 */
+	public function __construct( WP_User $user ) {
+		$this->user = $user;
+	}
+
+	/**
+	 * Get the email template slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email template slug.
+	 */
+	public static function get_template_slug() {
+		return 'delayed_downgrade_processed_admin';
+	}
+
+	/**
+	 * Get the "nice name" of the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "nice name" of the email template.
+	 */
+	public static function get_template_name() {
+		return esc_html__( 'Proration Downgrade Processed (Admin)', 'pmpro-proration' );
+	}
+
+	/**
+	 * Get "help text" to display to the admin when editing the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "help text" to display to the admin when editing the email template.
+	 */
+	public static function get_template_description() {
+		return esc_html__( 'This email is sent to the admin when a membership downgrade is processed.', 'pmpro-proration' );
+	}
+
+	/**
+	 * Get the default subject for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default subject for the email.
+	 */
+	public static function get_default_subject() {
+		return esc_html__( 'A membership downgrade has been processed', 'pmpro-proration' );
+	}
+
+	/**
+	 * Get the default body content for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default body content for the email.
+	 */
+	public static function get_default_body() {
+			return wp_kses_post( __( pmprorate_get_default_delayed_downgrade_processed_admin_email_body() ) );
+	}
+
+	/**
+	 * Get the email template variables for the email paired with a description of the variable.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public static function get_email_template_variables_with_description() {
+	
+		return array(
+			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+			'!!edit_member_downgrade_url!!' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
+		);
+	}
+
+	/**
+	 * Get the email template variables for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public function get_email_template_variables() {
+		$user = $this->user;
+		$email_template_variables = array(	
+			'display_name' => $user->display_name,
+			'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $user->ID . '&pmpro_member_edit_panel=pmprorate-downgrades' ),
+		);
+		return $email_template_variables;
+	}
+
+	/**
+	 * Get the email address to send the email to.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email address to send the email to.
+	 */
+	public function get_recipient_email() {
+		//send to the admin
+		return get_bloginfo( 'admin_email' );
+	}
+
+	/**
+	 * Get the name of the email recipient.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The name of the email recipient.
+	 */
+	public function get_recipient_name() {
+		$user = get_user_by( 'email', $this->get_recipient_email() );
+		return empty( $user->display_name ) ? esc_html__( 'Admin', 'pmpro-proration' ) : $user->display_name;
+	}
+
+	/**
+	 * Send a test email.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $email The email address to send the test email to.
+	 * @return bool Whether the email was sent successfully.
+	 */
+	public static function send_test( $email ) {
+		global $current_user;
+
+		//Instantiate this class with mock data to get access to the non-static methods
+		$test_checkout_check_template = new PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed_Admin( $current_user );
+
+		$test_email = new PMProEmail();
+		$test_email->email = $email;
+		$test_email->subject  =  self::get_default_subject();
+		// Add test mail text to the default body
+		$body = self::get_default_body();
+		$test_email->body = pmpro_email_templates_test_body( $body );
+		$test_email->data = array_merge( $test_checkout_check_template->get_base_email_template_variables(),
+			$test_checkout_check_template->get_email_template_variables() );
+		$test_email->template = self::get_template_slug();
+		return $test_email->sendEmail();
+	}
+}
+/**
+ * Register the email template.
+ *
+ * @since TBD
+ *
+ * @param array $email_templates The email templates (template slug => email template class name)
+ * @return array The modified email templates array.
+ */
+function pmpro_email_template_pmpro_proration_delayed_downgrade_processed_admin( $email_templates ) {
+	$email_templates['delayed_downgrade_processed_admin'] = 'PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed_Admin';
+	return $email_templates;
+}
+add_filter( 'pmpro_email_templates', 'pmpro_email_template_pmpro_proration_delayed_downgrade_processed_admin' );

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed-admin.php
@@ -73,7 +73,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed_Admin extends P
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-			return wp_kses_post( __( pmprorate_get_default_delayed_downgrade_processed_admin_email_body() ) );
+			return wp_kses_post( pmprorate_get_default_delayed_downgrade_processed_admin_email_body() );
 	}
 
 	/**
@@ -132,29 +132,18 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed_Admin extends P
 	}
 
 	/**
-	 * Send a test email.
+	 * Returns the arguments to send the test email from the abstract class.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $email The email address to send the test email to.
-	 * @return bool Whether the email was sent successfully.
+	 * @return array The arguments to send the test email from the abstract class.
 	 */
-	public static function send_test( $email ) {
+	public static function get_test_email_constructor_args() {
 		global $current_user;
 
-		//Instantiate this class with mock data to get access to the non-static methods
-		$test_checkout_check_template = new PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed_Admin( $current_user );
-
-		$test_email = new PMProEmail();
-		$test_email->email = $email;
-		$test_email->subject  =  self::get_default_subject();
-		// Add test mail text to the default body
-		$body = self::get_default_body();
-		$test_email->body = pmpro_email_templates_test_body( $body );
-		$test_email->data = array_merge( $test_checkout_check_template->get_base_email_template_variables(),
-			$test_checkout_check_template->get_email_template_variables() );
-		$test_email->template = self::get_template_slug();
-		return $test_email->sendEmail();
+		//Create test downgrade.
+		$test_downgrade = PMProrate_Downgrade::get_test_downgrade();
+		return array( $current_user, $test_downgrade );
 	}
 }
 /**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed-admin.php
@@ -15,7 +15,6 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed_Admin extends P
 	 * @since TBD
 	 *
 	 * @param WP_User $user The user downgrading.
-	 * @param PMProrate_Downgrade $downgrade The downgrade object.
 	 */
 	public function __construct( WP_User $user ) {
 		$this->user = $user;
@@ -140,10 +139,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed_Admin extends P
 	 */
 	public static function get_test_email_constructor_args() {
 		global $current_user;
-
-		//Create test downgrade.
-		$test_downgrade = PMProrate_Downgrade::get_test_downgrade();
-		return array( $current_user, $test_downgrade );
+		return array( $current_user );
 	}
 }
 /**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php
@@ -1,0 +1,177 @@
+<?php
+
+
+// $templates['delayed_downgrade_processed'] = array(
+// 	'subject' => esc_html( sprintf( __( 'Your downgrade has been processed at %s', 'pmpro-proration' ), get_option( 'blogname' ) ) ),
+// 	'description' => esc_html__( 'Proration Downgrade Processed', 'pmpro-proration' ),
+// 	'body' => pmprorate_get_default_delayed_downgrade_processed_email_body(),
+// 	'help_text' => esc_html__( 'This email is sent when a membership downgrade is processed.', 'pmpro-proration' ),
+// );
+
+class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_Email_Template {
+
+	/**
+	 * The parent user.
+	 *
+	 * @var WP_User
+	 */
+	protected $user;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_User $user The user downgrading.
+	 * @param PMProrate_Downgrade $downgrade The downgrade object.
+	 */
+	public function __construct( WP_User $user ) {
+		$this->user = $user;
+	}
+
+	/**
+	 * Get the email template slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email template slug.
+	 */
+	public static function get_template_slug() {
+		return 'delayed_downgrade_processed';
+	}
+
+	/**
+	 * Get the "nice name" of the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "nice name" of the email template.
+	 */
+	public static function get_template_name() {
+		return esc_html__( 'Proration Downgrade Processed', 'pmpro-proration' );
+	}
+
+	/**
+	 * Get "help text" to display to the admin when editing the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "help text" to display to the admin when editing the email template.
+	 */
+	public static function get_template_description() {
+		return esc_html__( 'This email is sent when a membership downgrade is processed.', 'pmpro-prorate' );
+	}
+
+	/**
+	 * Get the default subject for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default subject for the email.
+	 */
+	public static function get_default_subject() {
+		return esc_html__( sprintf( __( 'Your downgrade has been processed at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) );
+	}
+
+	/**
+	 * Get the default body content for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default body content for the email.
+	 */
+	public static function get_default_body() {
+			return wp_kses_post( __( pmprorate_get_default_delayed_downgrade_processed_email_body() ) );
+	}
+
+	/**
+	 * Get the email template variables for the email paired with a description of the variable.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public static function get_email_template_variables_with_description() {
+	
+		return array(
+			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+		);
+	}
+
+	/**
+	 * Get the email template variables for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public function get_email_template_variables() {
+		$user = $this->user;
+		$email_template_variables = array(	
+			'display_name' => $user->display_name,
+			'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $user->ID . '&pmpro_member_edit_panel=pmprorate-downgrades' ),
+		);
+		return $email_template_variables;
+	}
+
+	/**
+	 * Get the email address to send the email to.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email address to send the email to.
+	 */
+	public function get_recipient_email() {
+		return $this->user->user_email;
+	}
+
+	/**
+	 * Get the name of the email recipient.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The name of the email recipient.
+	 */
+	public function get_recipient_name() {
+		$user = $this->user;
+		return empty( $user->display_name ) ? esc_html__( 'User', 'pmpro-proration' ) : $user->display_name;
+	}
+
+	/**
+	 * Send a test email.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $email The email address to send the test email to.
+	 * @return bool Whether the email was sent successfully.
+	 */
+	public static function send_test( $email ) {
+		global $current_user;
+
+		//Instantiate this class with mock data to get access to the non-static methods
+		$test_checkout_check_template = new PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed( $current_user );
+
+		$test_email = new PMProEmail();
+		$test_email->email = $email;
+		$test_email->subject  =  self::get_default_subject();
+		// Add test mail text to the default body
+		$test_email->body = pmpro_email_templates_test_body( self::get_default_body() );
+		$test_email->data = array_merge( $test_checkout_check_template->get_base_email_template_variables(),
+			$test_checkout_check_template->get_email_template_variables() );
+		$test_email->template = self::get_template_slug();
+		return $test_email->sendEmail();
+	}
+}
+/**
+ * Register the email template.
+ *
+ * @since TBD
+ *
+ * @param array $email_templates The email templates (template slug => email template class name)
+ * @return array The modified email templates array.
+ */
+function pmpro_email_template_pmpro_proration_delayed_downgrade_processed( $email_templates ) {
+	$email_templates['delayed_downgrade_processed'] = 'PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed';
+	return $email_templates;
+}
+add_filter( 'pmpro_email_templates', 'pmpro_email_template_pmpro_proration_delayed_downgrade_processed' );

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php
@@ -70,7 +70,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_E
 	 * @return string The default subject for the email.
 	 */
 	public static function get_default_subject() {
-		return esc_html__( sprintf( __( 'Your downgrade has been processed at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) );
+		return esc_html( sprintf( __( 'Your downgrade has been processed at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) );
 	}
 
 	/**
@@ -81,7 +81,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_E
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-			return wp_kses_post( __( pmprorate_get_default_delayed_downgrade_processed_email_body() ) );
+			return wp_kses_post( pmprorate_get_default_delayed_downgrade_processed_email_body() );
 	}
 
 	/**
@@ -138,28 +138,18 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_E
 	}
 
 	/**
-	 * Send a test email.
+	 * Returns the arguments to send the test email from the abstract class.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $email The email address to send the test email to.
-	 * @return bool Whether the email was sent successfully.
+	 * @return array The arguments to send the test email from the abstract class.
 	 */
-	public static function send_test( $email ) {
+	public static function get_test_email_constructor_args() {
 		global $current_user;
 
-		//Instantiate this class with mock data to get access to the non-static methods
-		$test_checkout_check_template = new PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed( $current_user );
-
-		$test_email = new PMProEmail();
-		$test_email->email = $email;
-		$test_email->subject  =  self::get_default_subject();
-		// Add test mail text to the default body
-		$test_email->body = pmpro_email_templates_test_body( self::get_default_body() );
-		$test_email->data = array_merge( $test_checkout_check_template->get_base_email_template_variables(),
-			$test_checkout_check_template->get_email_template_variables() );
-		$test_email->template = self::get_template_slug();
-		return $test_email->sendEmail();
+		//Create test downgrade.
+		$test_downgrade = PMProrate_Downgrade::get_test_downgrade();
+		return array( $current_user, $test_downgrade );
 	}
 }
 /**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php
@@ -15,7 +15,6 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_E
 	 * @since TBD
 	 *
 	 * @param WP_User $user The user downgrading.
-	 * @param PMProrate_Downgrade $downgrade The downgrade object.
 	 */
 	public function __construct( WP_User $user ) {
 		$this->user = $user;
@@ -51,7 +50,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_E
 	 * @return string The "help text" to display to the admin when editing the email template.
 	 */
 	public static function get_template_description() {
-		return esc_html__( 'This email is sent when a membership downgrade is processed.', 'pmpro-prorations' );
+		return esc_html__( 'This email is sent when a membership downgrade is processed.', 'pmpro-proration' );
 	}
 
 	/**
@@ -62,7 +61,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_E
 	 * @return string The default subject for the email.
 	 */
 	public static function get_default_subject() {
-		return esc_html( sprintf( __( 'Your downgrade has been processed at %s', 'pmpro-prorations' ), get_option( 'blogname' ) ) );
+		return esc_html( sprintf( __( 'Your downgrade has been processed at %s', 'pmpro-proration' ), get_option( 'blogname' ) ) );
 	}
 
 	/**
@@ -138,10 +137,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_E
 	 */
 	public static function get_test_email_constructor_args() {
 		global $current_user;
-
-		//Create test downgrade.
-		$test_downgrade = PMProrate_Downgrade::get_test_downgrade();
-		return array( $current_user, $test_downgrade );
+		return array( $current_user );
 	}
 }
 /**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php
@@ -1,13 +1,5 @@
 <?php
 
-
-// $templates['delayed_downgrade_processed'] = array(
-// 	'subject' => esc_html( sprintf( __( 'Your downgrade has been processed at %s', 'pmpro-proration' ), get_option( 'blogname' ) ) ),
-// 	'description' => esc_html__( 'Proration Downgrade Processed', 'pmpro-proration' ),
-// 	'body' => pmprorate_get_default_delayed_downgrade_processed_email_body(),
-// 	'help_text' => esc_html__( 'This email is sent when a membership downgrade is processed.', 'pmpro-proration' ),
-// );
-
 class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_Email_Template {
 
 	/**
@@ -59,7 +51,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_E
 	 * @return string The "help text" to display to the admin when editing the email template.
 	 */
 	public static function get_template_description() {
-		return esc_html__( 'This email is sent when a membership downgrade is processed.', 'pmpro-prorate' );
+		return esc_html__( 'This email is sent when a membership downgrade is processed.', 'pmpro-prorations' );
 	}
 
 	/**
@@ -70,7 +62,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_E
 	 * @return string The default subject for the email.
 	 */
 	public static function get_default_subject() {
-		return esc_html( sprintf( __( 'Your downgrade has been processed at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) );
+		return esc_html( sprintf( __( 'Your downgrade has been processed at %s', 'pmpro-prorations' ), get_option( 'blogname' ) ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled-admin.php
@@ -1,0 +1,185 @@
+<?php
+
+class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled_Admin extends PMPro_Email_Template {
+
+	/**
+	 * The parent user.
+	 *
+	 * @var WP_User
+	 */
+	protected $user;
+
+	/**
+	 * The downgrade.
+	 *
+	 * @var PMProrate_Downgrade
+	 */
+	protected $downgrade;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_User $user The user downgrading.
+	 * @param PMProrate_Downgrade $downgrade The downgrade object.
+	 */
+	public function __construct( WP_User $user, PMProrate_Downgrade $downgrade ) {
+		$this->user = $user;
+		$this->downgrade = $downgrade;
+	}
+
+	/**
+	 * Get the email template slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email template slug.
+	 */
+	public static function get_template_slug() {
+		return 'delayed_downgrade_scheduled_admin';
+	}
+
+	/**
+	 * Get the "nice name" of the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "nice name" of the email template.
+	 */
+	public static function get_template_name() {
+		return esc_html__( 'Proration Downgrade Scheduled (Admin)', 'pmpro-proration' );
+	}
+
+	/**
+	 * Get "help text" to display to the admin when editing the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "help text" to display to the admin when editing the email template.
+	 */
+	public static function get_template_description() {
+		return esc_html__( 'This email is sent when a membership downgrade is scheduled. The !!edit_member_downgrade_url!! placeholder variable can be used to show a link to the downgrades list.', 'pmpro-proration' );
+	}
+
+	/**
+	 * Get the default subject for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default subject for the email.
+	 */
+	public static function get_default_subject() {
+		return esc_html( sprintf( __( 'A downgrade has been scheduled at %s', 'pmpro-proration' ), get_option( 'blogname' ) ) );
+	}
+
+	/**
+	 * Get the default body content for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default body content for the email.
+	 */
+	public static function get_default_body() {
+		return wp_kses_post( __( pmprorate_get_default_delayed_downgrade_scheduled_admin_email_body() ) );
+	}
+
+	/**
+	 * Get the email template variables for the email paired with a description of the variable.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public static function get_email_template_variables_with_description() {
+		return array(
+			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+			'!!edit_member_downgrade_url!!' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
+		);
+	}
+
+	/**
+	 * Get the email template variables for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public function get_email_template_variables() {
+		$user = $this->user;
+		$downgrade = $this->downgrade;
+
+		$email_template_variables = array(	
+			'display_name' => $user->display_name,
+			'pmprorate_downgrade_text' => $downgrade->get_downgrade_text(),
+			'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $user->ID . '&pmpro_member_edit_panel=pmprorate-downgrades' ),
+		);
+		return $email_template_variables;
+	}
+
+	/**
+	 * Get the email address to send the email to.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email address to send the email to.
+	 */
+	public function get_recipient_email() {
+		//send to the admin
+		return get_bloginfo( 'admin_email' );
+	}
+
+	/**
+	 * Get the name of the email recipient.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The name of the email recipient.
+	 */
+	public function get_recipient_name() {
+		$user = get_user_by( 'email', $this->get_recipient_email() );
+		return empty( $user->display_name ) ? esc_html__( 'Admin', 'pmpro-proration' ) : $user->display_name;
+	}
+
+	/**	
+	 * Send a test email.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $email The email address to send the test email to.
+	 * @return bool Whether the email was sent successfully.
+	 */
+	public static function send_test( $email ) {
+		global $current_user;
+
+		//Create test order
+		$test_downgrade = PMProrate_Downgrade::get_test_downgrade();
+
+		//Instantiate this class with mock data to get access to the non-static methods
+		$test_checkout_check_template = new PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled_Admin( $current_user, $test_downgrade );
+
+		$test_email = new PMProEmail();
+		$test_email->email = $email;
+		$test_email->subject  =  self::get_default_subject();
+		// Add test mail text to the default body
+		$test_email->body = pmpro_email_templates_test_body( self::get_default_body() );
+		$test_email->data = array_merge( $test_checkout_check_template->get_base_email_template_variables(),
+			$test_checkout_check_template->get_email_template_variables() );
+		$test_email->template = self::get_template_slug();
+		return $test_email->sendEmail();
+	}
+
+}
+/**
+ * Register the email template.
+ *
+ * @since TBD
+ *
+ * @param array $email_templates The email templates (template slug => email template class name)
+ * @return array The modified email templates array.
+ */
+function pmpro_email_template_pmpro_proration_delayed_downgrade_scheduled_admin( $email_templates ) {
+	$email_templates['delayed_downgrade_scheduled_admin'] = 'PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled_Admin';
+	return $email_templates;
+}
+add_filter( 'pmpro_email_templates', 'pmpro_email_template_pmpro_proration_delayed_downgrade_scheduled_admin' );

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled-admin.php
@@ -59,7 +59,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled_Admin extends P
 	 * @return string The "help text" to display to the admin when editing the email template.
 	 */
 	public static function get_template_description() {
-		return esc_html__( 'This email is sent when a membership downgrade is scheduled. The !!edit_member_downgrade_url!! placeholder variable can be used to show a link to the downgrades list.', 'pmpro-proration' );
+		return esc_html__( 'This email is sent when a membership downgrade is scheduled.', 'pmpro-proration' );
 	}
 
 	/**
@@ -81,7 +81,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled_Admin extends P
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( __( pmprorate_get_default_delayed_downgrade_scheduled_admin_email_body() ) );
+		return wp_kses_post( pmprorate_get_default_delayed_downgrade_scheduled_admin_email_body() );
 	}
 
 	/**
@@ -141,34 +141,20 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled_Admin extends P
 		return empty( $user->display_name ) ? esc_html__( 'Admin', 'pmpro-proration' ) : $user->display_name;
 	}
 
-	/**	
-	 * Send a test email.
+	/**
+	 * Returns the arguments to send the test email from the abstract class.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $email The email address to send the test email to.
-	 * @return bool Whether the email was sent successfully.
+	 * @return array The arguments to send the test email from the abstract class.
 	 */
-	public static function send_test( $email ) {
+	public static function get_test_email_constructor_args() {
 		global $current_user;
 
-		//Create test order
+		//Create test downgrade.
 		$test_downgrade = PMProrate_Downgrade::get_test_downgrade();
-
-		//Instantiate this class with mock data to get access to the non-static methods
-		$test_checkout_check_template = new PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled_Admin( $current_user, $test_downgrade );
-
-		$test_email = new PMProEmail();
-		$test_email->email = $email;
-		$test_email->subject  =  self::get_default_subject();
-		// Add test mail text to the default body
-		$test_email->body = pmpro_email_templates_test_body( self::get_default_body() );
-		$test_email->data = array_merge( $test_checkout_check_template->get_base_email_template_variables(),
-			$test_checkout_check_template->get_email_template_variables() );
-		$test_email->template = self::get_template_slug();
-		return $test_email->sendEmail();
+		return array( $current_user, $test_downgrade );
 	}
-
 }
 /**
  * Register the email template.

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php
@@ -1,0 +1,186 @@
+<?php
+
+class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_Email_Template {
+
+	/**
+	 * The parent user.
+	 *
+	 * @var WP_User
+	 */
+	protected $user;
+
+	/**
+	 * The downgrade.
+	 *
+	 * @var PMProrate_Downgrade
+	 */
+	protected $downgrade;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_User $user The user downgrading.
+	 * @param PMProrate_Downgrade $downgrade The downgrade object.
+	 */
+	public function __construct( WP_User $user, PMProrate_Downgrade $downgrade ) {
+		$this->user = $user;
+		$this->downgrade = $downgrade;
+	}
+
+	/**
+	 * Get the email template slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email template slug.
+	 */
+	public static function get_template_slug() {
+		return 'delayed_downgrade_scheduled';
+	}
+
+	/**
+	 * Get the "nice name" of the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "nice name" of the email template.
+	 */
+	public static function get_template_name() {
+		return esc_html__( 'Proration Downgrade Scheduled', 'pmpro-prorate' );
+	}
+
+	/**
+	 * Get "help text" to display to the admin when editing the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "help text" to display to the admin when editing the email template.
+	 */
+	public static function get_template_description() {
+		return esc_html__( 'This email is sent when a membership downgrade is scheduled.', 'pmpro-prorate' );
+	}
+
+	/**
+	 * Get the default subject for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default subject for the email.
+	 */
+	public static function get_default_subject() {
+		return esc_html__( sprintf( __( 'Your downgrade has been scheduled at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) );
+	}
+
+	/**
+	 * Get the default body content for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default body content for the email.
+	 */
+	public static function get_default_body() {
+		return wp_kses_post( __( pmprorate_get_default_delayed_downgrade_scheduled_email_body() ) );
+	}
+
+	/**
+	 * Get the email template variables for the email paired with a description of the variable.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public static function get_email_template_variables_with_description() {
+
+
+		return array(
+			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+			'!!pmprorate_downgrade_text!!' => esc_html__( 'The text of the downgrade.', 'pmpro-proration' ),
+			'!!edit_member_downgrade_url!!' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
+		);
+	}
+
+	/**
+	 * Get the email template variables for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public function get_email_template_variables() {
+		$user = $this->user;
+		$downgrade = $this->downgrade;
+
+		$email_template_variables = array(	
+			'display_name' => $user->display_name,
+			'pmprorate_downgrade_text' => $downgrade->get_downgrade_text(),
+			'edit_member_downgrade_url' => admin_url( 'admin.php?page=pmpro-member&user_id=' . $user->ID . '&pmpro_member_edit_panel=pmprorate-downgrades' ),
+		);
+		return $email_template_variables;
+	}
+
+	/**
+	 * Get the email address to send the email to.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email address to send the email to.
+	 */
+	public function get_recipient_email() {
+		return $this->user->user_email;
+	}
+
+	/**
+	 * Get the name of the email recipient.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The name of the email recipient.
+	 */
+	public function get_recipient_name() {
+		$user = $this->user;
+		return empty( $user->display_name ) ? esc_html__( 'User', 'pmpro-proration' ) : $user->display_name;
+	}
+
+	/**
+	 * Send a test email.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $email The email address to send the test email to.
+	 * @return bool Whether the email was sent successfully.
+	 */
+	public static function send_test( $email ) {
+		global $current_user;
+
+		//Create test order
+		$test_downgrade = PMProrate_Downgrade::get_test_downgrade();
+
+		//Instantiate this class with mock data to get access to the non-static methods
+		$test_checkout_check_template = new PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled( $current_user, $test_downgrade );
+
+		$test_email = new PMProEmail();
+		$test_email->email = $email;
+		$test_email->subject  =  self::get_default_subject();
+		// Add test mail text to the default body
+		$test_email->body = pmpro_email_templates_test_body( self::get_default_body() );
+		$test_email->data = array_merge( $test_checkout_check_template->get_base_email_template_variables(),
+			$test_checkout_check_template->get_email_template_variables() );
+		$test_email->template = self::get_template_slug();
+		return $test_email->sendEmail();
+	}
+}
+/**
+ * Register the email template.
+ *
+ * @since TBD
+ *
+ * @param array $email_templates The email templates (template slug => email template class name)
+ * @return array The modified email templates array.
+ */
+function pmpro_email_template_pmpro_proration_delayed_downgrade_scheduled( $email_templates ) {
+	$email_templates['delayed_downgrade_scheduled'] = 'PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled';
+	return $email_templates;
+}
+add_filter( 'pmpro_email_templates', 'pmpro_email_template_pmpro_proration_delayed_downgrade_scheduled' );

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php
@@ -48,7 +48,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_E
 	 * @return string The "nice name" of the email template.
 	 */
 	public static function get_template_name() {
-		return esc_html__( 'Proration Downgrade Scheduled', 'pmpro-prorate' );
+		return esc_html__( 'Proration Downgrade Scheduled', 'pmpro-prorations' );
 	}
 
 	/**
@@ -59,7 +59,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_E
 	 * @return string The "help text" to display to the admin when editing the email template.
 	 */
 	public static function get_template_description() {
-		return esc_html__( 'This email is sent when a membership downgrade is scheduled.', 'pmpro-prorate' );
+		return esc_html__( 'This email is sent when a membership downgrade is scheduled.', 'pmpro-prorations' );
 	}
 
 	/**
@@ -70,7 +70,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_E
 	 * @return string The default subject for the email.
 	 */
 	public static function get_default_subject() {
-		return esc_html( sprintf( __( 'Your downgrade has been scheduled at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) );
+		return esc_html( sprintf( __( 'Your downgrade has been scheduled at %s', 'pmpro-prorations' ), get_option( 'blogname' ) ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php
@@ -70,7 +70,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_E
 	 * @return string The default subject for the email.
 	 */
 	public static function get_default_subject() {
-		return esc_html__( sprintf( __( 'Your downgrade has been scheduled at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) );
+		return esc_html( sprintf( __( 'Your downgrade has been scheduled at %s', 'pmpro-prorate' ), get_option( 'blogname' ) ) );
 	}
 
 	/**
@@ -81,7 +81,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_E
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( __( pmprorate_get_default_delayed_downgrade_scheduled_email_body() ) );
+		return wp_kses_post( pmprorate_get_default_delayed_downgrade_scheduled_email_body() );
 	}
 
 	/**
@@ -144,31 +144,18 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_E
 	}
 
 	/**
-	 * Send a test email.
+	 * Returns the arguments to send the test email from the abstract class.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $email The email address to send the test email to.
-	 * @return bool Whether the email was sent successfully.
+	 * @return array The arguments to send the test email from the abstract class.
 	 */
-	public static function send_test( $email ) {
+	public static function get_test_email_constructor_args() {
 		global $current_user;
 
-		//Create test order
+		//Create test downgrade.
 		$test_downgrade = PMProrate_Downgrade::get_test_downgrade();
-
-		//Instantiate this class with mock data to get access to the non-static methods
-		$test_checkout_check_template = new PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled( $current_user, $test_downgrade );
-
-		$test_email = new PMProEmail();
-		$test_email->email = $email;
-		$test_email->subject  =  self::get_default_subject();
-		// Add test mail text to the default body
-		$test_email->body = pmpro_email_templates_test_body( self::get_default_body() );
-		$test_email->data = array_merge( $test_checkout_check_template->get_base_email_template_variables(),
-			$test_checkout_check_template->get_email_template_variables() );
-		$test_email->template = self::get_template_slug();
-		return $test_email->sendEmail();
+		return array( $current_user, $test_downgrade );
 	}
 }
 /**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php
@@ -48,7 +48,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_E
 	 * @return string The "nice name" of the email template.
 	 */
 	public static function get_template_name() {
-		return esc_html__( 'Proration Downgrade Scheduled', 'pmpro-prorations' );
+		return esc_html__( 'Proration Downgrade Scheduled', 'pmpro-proration' );
 	}
 
 	/**
@@ -59,7 +59,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_E
 	 * @return string The "help text" to display to the admin when editing the email template.
 	 */
 	public static function get_template_description() {
-		return esc_html__( 'This email is sent when a membership downgrade is scheduled.', 'pmpro-prorations' );
+		return esc_html__( 'This email is sent when a membership downgrade is scheduled.', 'pmpro-proration' );
 	}
 
 	/**
@@ -70,7 +70,7 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_E
 	 * @return string The default subject for the email.
 	 */
 	public static function get_default_subject() {
-		return esc_html( sprintf( __( 'Your downgrade has been scheduled at %s', 'pmpro-prorations' ), get_option( 'blogname' ) ) );
+		return esc_html( sprintf( __( 'Your downgrade has been scheduled at %s', 'pmpro-proration' ), get_option( 'blogname' ) ) );
 	}
 
 	/**

--- a/includes/emails.php
+++ b/includes/emails.php
@@ -41,7 +41,25 @@ function pmprorate_template_callback( $templates ) {
 	
 	return $templates;
 }
-add_filter( 'pmproet_templates', 'pmprorate_template_callback');
+
+/**
+ * Either requires PMPro Email Templates or adds the templates to the email templates.
+ *
+ * @since TBD
+ */
+function pmprorate_add_templates() {
+	if (  class_exists( 'PMPro_Email_Template' ) ) {
+		require_once( PMPRORATE_DIR . '/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php' );
+		require_once( PMPRORATE_DIR . '/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled-admin.php' );
+		require_once( PMPRORATE_DIR . '/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php' );
+		require_once( PMPRORATE_DIR . '/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed-admin.php' );
+		require_once( PMPRORATE_DIR . '/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php' );
+	} else {
+		add_filter( 'pmproet_templates', 'pmprorate_template_callback');
+	}
+
+}
+add_action( 'init', 'pmprorate_add_templates', 8 );
 
 /**
  * Default email content for the delayed_downgrade_scheduled email template.


### PR DESCRIPTION

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/26834166-9703-4329-b644-8757a99d074c" />


### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-proration/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-proration/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add 5 new classes to send the emails through the v3.4+ 

- PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin
- PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed_Admin
- PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed
- PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled_Admin
- PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled

Either require these classes files or add the templates on 'pmproet_templates' filter 

In the different places where the email are being sent, check if the `PMPro_Email_Template` class exists and send the emails with the new aproach

### How to test the changes in this Pull Request:

It's a bit hard to fire the different emails, the way I found is editing DB to match conditions or even directly editing source to fire for example the error email.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
