### PR TITLE
Fixing order link for PMPro v3.6+

### DIFF
--- a/classes/pmprorate-class-member-edit-panel-downgrades.php
+++ b/classes/pmprorate-class-member-edit-panel-downgrades.php
@@ -53,7 +53,7 @@ class PMProrate_Member_Edit_Panel_Downgrades extends PMPro_Member_Edit_Panel {
 
 					// Get the order object and link.
 					$downgrade_order = new MemberOrder( $downgrade->downgrade_order_id );
-					$downgrade_order_link = add_query_arg( array( 'page' => 'pmpro-orders', 'order' => $downgrade->downgrade_order_id ), admin_url( 'admin.php' ) );
+					$downgrade_order_link = add_query_arg( array( 'page' => 'pmpro-orders', 'order' => $downgrade->downgrade_order_id, 'id' => $downgrade->downgrade_order_id ), admin_url( 'admin.php' ) );
 
 					// Get the status text and class to show.
 					switch ( $downgrade->status ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing broken link to view orders when running PMPro v3.6+

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
