### PR TITLE
Fix downgrade level mutation when pmpro-affiliates active

### DIFF
--- a/includes/delayed-downgrades.php
+++ b/includes/delayed-downgrades.php
@@ -71,6 +71,10 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 	// Capture the checkout level early before any hooks (e.g. pmpro-affiliates) can mutate the global.
 	$checkout_level = clone $pmpro_level;
 
+	// Get the actual level definition from the database (without discount code adjustments)
+	// to check if this level truly has recurring billing.
+	$actual_level = pmpro_getLevel( $pmpro_level->id );
+
 	// If we don't have an order, then this checkout is free. Create a free order.
 	if ( empty( $order ) ) {
 		// Get the user's email address.
@@ -119,7 +123,7 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 		// If the level being purchased will not have a subscription, set the expiration date for the
 		// user's current membership to the next payment date of their current subscription.
 		// This is so that we know when to downgrade the membership without an active subscription.
-		if ( empty( (float)$checkout_level->billing_amount) ) {
+		if ( empty( (float)$actual_level->billing_amount) ) {
 			// Get the next payment date for the user's current subscription.
 			$next_payment_date = $old_subscriptions[0]->get_next_payment_date( 'Y-m-d H:i:s' );
 			$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->pmpro_memberships_users SET enddate = %s WHERE user_id = %d AND membership_id = %d AND status = 'active'", $next_payment_date, $user_id, $downgrading_from_id ) );

--- a/includes/delayed-downgrades.php
+++ b/includes/delayed-downgrades.php
@@ -68,6 +68,9 @@ function pmprorate_added_order_mark_order_as_downgrade( $order ) {
 function pmprorate_checkout_before_change_membership_level_remember_downgrade( $user_id, $order ) {
 	global $wpdb, $pmpro_level, $pmprorate_is_downgrade;
 
+	// Capture the checkout level early before any hooks (e.g. pmpro-affiliates) can mutate the global.
+	$checkout_level = clone $pmpro_level;
+
 	// If we don't have an order, then this checkout is free. Create a free order.
 	if ( empty( $order ) ) {
 		// Get the user's email address.
@@ -81,7 +84,7 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 		$order->status         = 'success';
 		$order = apply_filters( "pmpro_checkout_order_free", $order );
 		$order->user_id       = $user_id;
-		$order->membership_id = $pmpro_level->id;
+		$order->membership_id = $checkout_level->id;
 	}
 
 	// Get the level for the order.
@@ -116,7 +119,7 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 		// If the level being purchased will not have a subscription, set the expiration date for the
 		// user's current membership to the next payment date of their current subscription.
 		// This is so that we know when to downgrade the membership without an active subscription.
-		if ( empty( (float)$pmpro_level->billing_amount) ) {
+		if ( empty( (float)$checkout_level->billing_amount) ) {
 			// Get the next payment date for the user's current subscription.
 			$next_payment_date = $old_subscriptions[0]->get_next_payment_date( 'Y-m-d H:i:s' );
 			$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->pmpro_memberships_users SET enddate = %s WHERE user_id = %d AND membership_id = %d AND status = 'active'", $next_payment_date, $user_id, $downgrading_from_id ) );
@@ -145,7 +148,7 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 	}
 
 	// Create the downgrade.
-	$downgrade = PMProrate_Downgrade::create( $user_id, $downgrading_from_id, $pmpro_level->id, $order->id );
+	$downgrade = PMProrate_Downgrade::create( $user_id, $downgrading_from_id, $checkout_level->id, $order->id );
 	if ( empty( $downgrade ) ) {
 		// Creating the downgrade failed. Bail and let PMPro handle the checkout normally.
 		return;


### PR DESCRIPTION
## Summary

- Use `pmpro_getLevel()` to fetch the raw level definition (without discount code adjustments) for the billing_amount check
- Retain the `clone $pmpro_level` defensive copy to protect against mid-function mutation of the global by other plugins
- Fixes false non-recurring detection when discount codes (e.g. from pmpro-affiliates) reduce billing_amount to $0

## Problem

When pmpro-affiliates (or any discount code plugin) is active, `$pmpro_level->billing_amount` at checkout time reflects the **discounted** price, not the actual level's recurring billing amount. A 100% affiliate discount makes `billing_amount` appear as `$0`, causing the delayed downgrade handler to incorrectly treat a recurring level as non-recurring.

Specifically, on line 122:
```php
if ( empty( (float)$checkout_level->billing_amount ) ) {
```

This check determines whether to set an expiration date on the old membership (for non-recurring downgrades). When a discount code zeroes out the billing amount, this condition is `true` even though the level itself has recurring billing — leading to incorrect expiration date behavior on the old membership.

The original clone fix (protecting against mid-function mutation via `saveOrder()` hooks) was necessary but insufficient. The deeper issue is that discount code pricing is already baked into `$pmpro_level` **before** this handler runs.

## Fix

1. **`pmpro_getLevel($pmpro_level->id)`** fetches the raw level definition from the database — no discount codes, no checkout adjustments. This is used for the billing_amount check to determine if the level truly has recurring billing.
2. **`clone $pmpro_level`** is retained as defensive coding. It protects `$checkout_level->id` references from mutation by hooks fired during `$order->saveOrder()` (the original affiliates mutation bug).

## Test plan

- [ ] Downgrade checkout **without** pmpro-affiliates — verify downgrade record has correct `new_level_id` and billing detection works (regression test)
- [ ] Downgrade checkout **with** pmpro-affiliates and an affiliate cookie that gives 100% discount — verify the level is still correctly detected as recurring, and no spurious expiration date is set on the old membership
- [ ] Downgrade checkout **with** a partial discount code — verify billing detection still sees the level as recurring
- [ ] Downgrade to a genuinely free/non-recurring level — verify the expiration date logic still triggers correctly
- [ ] Free level downgrade (no order created) — verify the free order gets the correct `membership_id` from the clone
- [ ] Upgrade checkout (non-downgrade) — verify no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)