### PR TITLE
Update email templates to use liquid syntax for PMPro 3.7+

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php
@@ -72,7 +72,13 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( pmprorate_get_default_delayed_downgrade_error_admin_email_body() );
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return wp_kses_post( pmprorate_get_default_delayed_downgrade_error_admin_email_body() );
+		}
+		$body = '<p>' . esc_html__( 'There was an error processing a downgrade for {{ display_name }} at {{ sitename }}.', 'pmpro-proration' ) . '</p>' . "\n";
+		$body .= '<p>' . esc_html__( "View the user's downgrade information here:", 'pmpro-proration' ) . ' {{ edit_member_downgrade_url }}</p>' . "\n";
+		return $body;
 	}
 
 	/**
@@ -83,10 +89,16 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public static function get_email_template_variables_with_description() {
-	
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return array(
+				'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+				'!!edit_member_downgrade_url!!' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
+			);
+		}
 		return array(
-			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
-			'!!edit_member_downgrade_url!!' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
+			'{{ display_name }}' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+			'{{ edit_member_downgrade_url }}' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-error-admin.php
@@ -76,9 +76,9 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Error_Admin extends PMPro
 			// Running a version of PMPro before liquid email rendering was available.
 			return wp_kses_post( pmprorate_get_default_delayed_downgrade_error_admin_email_body() );
 		}
-		$body = '<p>' . esc_html__( 'There was an error processing a downgrade for {{ display_name }} at {{ sitename }}.', 'pmpro-proration' ) . '</p>' . "\n";
-		$body .= '<p>' . esc_html__( "View the user's downgrade information here:", 'pmpro-proration' ) . ' {{ edit_member_downgrade_url }}</p>' . "\n";
-		return $body;
+		return wp_kses_post( __( '<p>There was an error processing a downgrade for {{ display_name }} at {{ sitename }}.</p>
+
+<p>View the user\'s downgrade information here: {{ edit_member_downgrade_url }}</p>', 'pmpro-proration' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed-admin.php
@@ -72,7 +72,13 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed_Admin extends P
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
 			return wp_kses_post( pmprorate_get_default_delayed_downgrade_processed_admin_email_body() );
+		}
+		$body = '<p>' . esc_html__( 'A downgrade for {{ display_name }} has been successfully processed at {{ sitename }}.', 'pmpro-proration' ) . '</p>' . "\n";
+		$body .= '<p>' . esc_html__( "View the user's downgrade information here:", 'pmpro-proration' ) . ' {{ edit_member_downgrade_url }}</p>' . "\n";
+		return $body;
 	}
 
 	/**
@@ -83,10 +89,16 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed_Admin extends P
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public static function get_email_template_variables_with_description() {
-	
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return array(
+				'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+				'!!edit_member_downgrade_url!!' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
+			);
+		}
 		return array(
-			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
-			'!!edit_member_downgrade_url!!' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
+			'{{ display_name }}' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+			'{{ edit_member_downgrade_url }}' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed-admin.php
@@ -76,9 +76,9 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed_Admin extends P
 			// Running a version of PMPro before liquid email rendering was available.
 			return wp_kses_post( pmprorate_get_default_delayed_downgrade_processed_admin_email_body() );
 		}
-		$body = '<p>' . esc_html__( 'A downgrade for {{ display_name }} has been successfully processed at {{ sitename }}.', 'pmpro-proration' ) . '</p>' . "\n";
-		$body .= '<p>' . esc_html__( "View the user's downgrade information here:", 'pmpro-proration' ) . ' {{ edit_member_downgrade_url }}</p>' . "\n";
-		return $body;
+		return wp_kses_post( __( '<p>A downgrade for {{ display_name }} has been successfully processed at {{ sitename }}.</p>
+
+<p>View the user\'s downgrade information here: {{ edit_member_downgrade_url }}</p>', 'pmpro-proration' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php
@@ -72,7 +72,13 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_E
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
 			return wp_kses_post( pmprorate_get_default_delayed_downgrade_processed_email_body() );
+		}
+		$body = '<p>' . esc_html__( 'Your downgrade has been successfully processed.', 'pmpro-proration' ) . '</p>' . "\n";
+		$body .= '<p>' . esc_html__( 'Log in to view your account here:', 'pmpro-proration' ) . ' {{ login_url }}</p>' . "\n";
+		return $body;
 	}
 
 	/**
@@ -83,9 +89,14 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_E
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public static function get_email_template_variables_with_description() {
-	
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return array(
+				'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+			);
+		}
 		return array(
-			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+			'{{ display_name }}' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-processed.php
@@ -76,9 +76,9 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Processed extends PMPro_E
 			// Running a version of PMPro before liquid email rendering was available.
 			return wp_kses_post( pmprorate_get_default_delayed_downgrade_processed_email_body() );
 		}
-		$body = '<p>' . esc_html__( 'Your downgrade has been successfully processed.', 'pmpro-proration' ) . '</p>' . "\n";
-		$body .= '<p>' . esc_html__( 'Log in to view your account here:', 'pmpro-proration' ) . ' {{ login_url }}</p>' . "\n";
-		return $body;
+		return wp_kses_post( __( '<p>Your downgrade has been successfully processed.</p>
+
+<p>Log in to view your account here: {{ login_url }}</p>', 'pmpro-proration' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled-admin.php
@@ -81,7 +81,13 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled_Admin extends P
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( pmprorate_get_default_delayed_downgrade_scheduled_admin_email_body() );
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return wp_kses_post( pmprorate_get_default_delayed_downgrade_scheduled_admin_email_body() );
+		}
+		$body = '<p>' . esc_html__( 'A downgrade for {{ display_name }} has been scheduled at {{ sitename }}.', 'pmpro-proration' ) . '</p>' . "\n";
+		$body .= '<p>' . esc_html__( "View the user's downgrade information here:", 'pmpro-proration' ) . ' {{ edit_member_downgrade_url }}</p>' . "\n";
+		return $body;
 	}
 
 	/**
@@ -92,9 +98,16 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled_Admin extends P
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public static function get_email_template_variables_with_description() {
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return array(
+				'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+				'!!edit_member_downgrade_url!!' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
+			);
+		}
 		return array(
-			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
-			'!!edit_member_downgrade_url!!' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
+			'{{ display_name }}' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+			'{{ edit_member_downgrade_url }}' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled-admin.php
@@ -85,9 +85,9 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled_Admin extends P
 			// Running a version of PMPro before liquid email rendering was available.
 			return wp_kses_post( pmprorate_get_default_delayed_downgrade_scheduled_admin_email_body() );
 		}
-		$body = '<p>' . esc_html__( 'A downgrade for {{ display_name }} has been scheduled at {{ sitename }}.', 'pmpro-proration' ) . '</p>' . "\n";
-		$body .= '<p>' . esc_html__( "View the user's downgrade information here:", 'pmpro-proration' ) . ' {{ edit_member_downgrade_url }}</p>' . "\n";
-		return $body;
+		return wp_kses_post( __( '<p>A downgrade for {{ display_name }} has been scheduled at {{ sitename }}.</p>
+
+<p>View the user\'s downgrade information here: {{ edit_member_downgrade_url }}</p>', 'pmpro-proration' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php
@@ -85,9 +85,9 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_E
 			// Running a version of PMPro before liquid email rendering was available.
 			return wp_kses_post( pmprorate_get_default_delayed_downgrade_scheduled_email_body() );
 		}
-		$body = '<p>{{ pmprorate_downgrade_text }}</p>' . "\n";
-		$body .= '<p>' . esc_html__( 'Log in to view your account here:', 'pmpro-proration' ) . ' {{ login_url }}</p>' . "\n";
-		return $body;
+		return wp_kses_post( __( '<p>{{ pmprorate_downgrade_text }}</p>
+
+<p>Log in to view your account here: {{ login_url }}</p>', 'pmpro-proration' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-proration-delayed-downgrade-scheduled.php
@@ -81,7 +81,13 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_E
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( pmprorate_get_default_delayed_downgrade_scheduled_email_body() );
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return wp_kses_post( pmprorate_get_default_delayed_downgrade_scheduled_email_body() );
+		}
+		$body = '<p>{{ pmprorate_downgrade_text }}</p>' . "\n";
+		$body .= '<p>' . esc_html__( 'Log in to view your account here:', 'pmpro-proration' ) . ' {{ login_url }}</p>' . "\n";
+		return $body;
 	}
 
 	/**
@@ -92,12 +98,18 @@ class PMPro_Email_Template_PMProRate_Delayed_Downgrade_Scheduled extends PMPro_E
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public static function get_email_template_variables_with_description() {
-
-
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return array(
+				'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+				'!!pmprorate_downgrade_text!!' => esc_html__( 'The text of the downgrade.', 'pmpro-proration' ),
+				'!!edit_member_downgrade_url!!' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
+			);
+		}
 		return array(
-			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
-			'!!pmprorate_downgrade_text!!' => esc_html__( 'The text of the downgrade.', 'pmpro-proration' ),
-			'!!edit_member_downgrade_url!!' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
+			'{{ display_name }}' => esc_html__( 'The user\'s display name.', 'pmpro-proration' ),
+			'{{ pmprorate_downgrade_text }}' => esc_html__( 'The text of the downgrade.', 'pmpro-proration' ),
+			'{{ edit_member_downgrade_url }}' => esc_html__( 'The URL to edit the member\'s downgrade.', 'pmpro-proration' ),
 		);
 	}
 


### PR DESCRIPTION
## Summary
- Updates all 5 email template classes to support PMPro 3.7+ liquid variable syntax in get_default_body() and get_email_template_variables_with_description() methods.
- Falls back to legacy !! syntax when PMPro_Liquid_Renderer class is not available (older PMPro versions).
- No changes to get_email_template_variables() methods (these do not use !! syntax).

## Test plan
- [ ] Verify emails render correctly with PMPro 3.7+ (liquid syntax should be used).
- [ ] Verify emails render correctly with PMPro < 3.7 (legacy !! syntax should be used).
- [ ] Confirm all 5 email templates send properly: scheduled, scheduled (admin), processed, processed (admin), error (admin).