### PR TITLE
Fix delayed downgrades for onsite checkouts

### DIFF
--- a/includes/delayed-downgrades.php
+++ b/includes/delayed-downgrades.php
@@ -116,7 +116,7 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 		// If the level being purchased will not have a subscription, set the expiration date for the
 		// user's current membership to the next payment date of their current subscription.
 		// This is so that we know when to downgrade the membership without an active subscription.
-		if ( empty( (float)$pmpro_level->billing_amount) ) {
+		if ( empty( (float)$level->billing_amount) ) {
 			// Get the next payment date for the user's current subscription.
 			$next_payment_date = $old_subscriptions[0]->get_next_payment_date( 'Y-m-d H:i:s' );
 			$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->pmpro_memberships_users SET enddate = %s WHERE user_id = %d AND membership_id = %d AND status = 'active'", $next_payment_date, $user_id, $downgrading_from_id ) );
@@ -145,7 +145,7 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 	}
 
 	// Create the downgrade.
-	$downgrade = PMProrate_Downgrade::create( $user_id, $downgrading_from_id, $pmpro_level->id, $order->id );
+	$downgrade = PMProrate_Downgrade::create( $user_id, $downgrading_from_id, $level->id, $order->id );
 	if ( empty( $downgrade ) ) {
 		// Creating the downgrade failed. Bail and let PMPro handle the checkout normally.
 		return;

--- a/includes/delayed-downgrades.php
+++ b/includes/delayed-downgrades.php
@@ -128,8 +128,15 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 		}
 	}
 
-	// Backup the current global checkout level.
-	$pmpro_level_backup = $pmpro_level;
+	// Clone $pmpro_level so we can restore it after $order->saveOrder().
+	// saveOrder() fires the `pmpro_added_order` action, and some hooks on
+	// that action (e.g. the Affiliates Add On) can overwrite the global
+	// $pmpro_level. We need the original checkout level intact below when
+	// we create the PMProrate_Downgrade so the downgrade records the level
+	// the user is downgrading *to*, not the level they are downgrading from.
+	// We clone (rather than just copy the reference) so a hook that mutates
+	// $pmpro_level's properties doesn't also mutate our backup.
+	$pmpro_level_backup = is_object( $pmpro_level ) ? clone $pmpro_level : $pmpro_level;
 
 	// Update the order's membership level ID to the level that the user is downgrading from.
 	$order->membership_id = $downgrading_from_id;
@@ -137,7 +144,8 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 	$order->status  = 'success';
 	$order->saveOrder();
 
-	// Restore the saved global checkout level.
+	// Restore the original checkout level so PMProrate_Downgrade::create() below
+	// uses the level the user is downgrading to.
 	$pmpro_level = $pmpro_level_backup;
 
 	// Save the data collected at checkout to the order.

--- a/includes/delayed-downgrades.php
+++ b/includes/delayed-downgrades.php
@@ -116,7 +116,7 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 		// If the level being purchased will not have a subscription, set the expiration date for the
 		// user's current membership to the next payment date of their current subscription.
 		// This is so that we know when to downgrade the membership without an active subscription.
-		if ( empty( (float)$level->billing_amount) ) {
+		if ( empty( (float)$pmpro_level->billing_amount) ) {
 			// Get the next payment date for the user's current subscription.
 			$next_payment_date = $old_subscriptions[0]->get_next_payment_date( 'Y-m-d H:i:s' );
 			$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->pmpro_memberships_users SET enddate = %s WHERE user_id = %d AND membership_id = %d AND status = 'active'", $next_payment_date, $user_id, $downgrading_from_id ) );
@@ -128,11 +128,17 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 		}
 	}
 
+	// Backup the current global checkout level.
+	$pmpro_level_backup = $pmpro_level;
+
 	// Update the order's membership level ID to the level that the user is downgrading from.
 	$order->membership_id = $downgrading_from_id;
 	$order->user_id = $user_id;
 	$order->status  = 'success';
 	$order->saveOrder();
+
+	// Restore the saved global checkout level.
+	$pmpro_level = $pmpro_level_backup;
 
 	// Save the data collected at checkout to the order.
 	pmpro_save_checkout_data_to_order( $order );
@@ -145,7 +151,7 @@ function pmprorate_checkout_before_change_membership_level_remember_downgrade( $
 	}
 
 	// Create the downgrade.
-	$downgrade = PMProrate_Downgrade::create( $user_id, $downgrading_from_id, $level->id, $order->id );
+	$downgrade = PMProrate_Downgrade::create( $user_id, $downgrading_from_id, $pmpro_level->id, $order->id );
 	if ( empty( $downgrade ) ) {
 		// Creating the downgrade failed. Bail and let PMPro handle the checkout normally.
 		return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-proration/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-proration/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
For sites using Stripe onsite checkout, the delayed downgrade level can be incorrectly set to the level you're downgrading from in some cases.

I can replicate this consistently as follows:
1. Set Stripe onsite as your gateway.
2. Create two recurring levels, e.g., Gold for $10 per month and Silver for $5 per month.
3. Activate Proration and Affiliates Add Ons.
4. Under _Memberships > Affiliates > Settings_, set _Credit for Recurring Orders_ to _Yes_.
5. Complete a checkout for the $10pm level.
6. Complete a checkout for the $5pm level, a downgrade.
7. Observe that you are listed as Downgrading from Gold to Gold on the post-checkout Order page, the Membership Account page, and Edit Member > Delayed Downgrades page.
8. Observe that when the delayed downgrade is eventually processed (can use Stripe test clocks to advance time), the Gold membership is retained and the subscription for the downgrade level is cancelled. 

![gold-to-silver-dd](https://github.com/user-attachments/assets/5896977f-ddeb-445a-b6d8-369bd42fcbc4)

This PR resolves the issue for onsite checkouts by caching the `$pmpro_level` global before calling `$order->saveOrder();` which triggers functions hooked into `pmpro_added_order` in the Affiliates Add On that can modify the global.

Other offsite gateways work same as before after the change.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Resolves an issue where an incorrect downgrade level could be set when using Stripe onsite checkout.
