### PR TITLE
Credit-as-time delay for annual → shorter-period upgrades

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -250,6 +250,90 @@ function pmprorate_pmpro_checkout_level( $level ) {
 	// Get the credit for the remaining time on the old level.
 	$credit = $prev_order->subtotal * $per_left;
 
+	/*
+	 * Credit-as-time delay for annual → shorter-period upgrades.
+	 *
+	 * When a member with an active annual (or longer) subscription checks out
+	 * for a recurring level with a shorter cycle period AND a higher cost per
+	 * day, the existing "different payment periods" branch below would charge
+	 * the new level's full initial payment today (minus a partial-month credit
+	 * that almost never offsets a full annual prepayment). The new monthly
+	 * subscription would also start billing immediately, so the customer
+	 * effectively forfeits the unused portion of the annual they prepaid.
+	 *
+	 * Instead, when this is a clear "I want more functionality now" upgrade,
+	 * charge $0 today and defer the new subscription's first billing date by
+	 * the number of days the remaining credit buys at the new daily rate.
+	 *
+	 * Downgrades by cost-per-day already use the delayed-downgrade flow above.
+	 */
+	$old_cycle_period   = $clevel->cycle_period;
+	$old_billing_amount = $clevel->billing_amount;
+	$old_cycle_number   = $clevel->cycle_number;
+	if ( class_exists( 'PMPro_Subscription' ) && ! empty( $current_subscription ) ) {
+		// Prefer the live subscription's billing config (matches what we did for
+		// pmprorate_have_same_payment_period() / pmprorate_isDowngrade()).
+		$old_cycle_period   = $current_subscription->get_cycle_period();
+		$old_billing_amount = $current_subscription->get_billing_amount();
+		$old_cycle_number   = $current_subscription->get_cycle_number();
+	}
+
+	if (
+		'Year' === $old_cycle_period &&
+		in_array( $level->cycle_period, array( 'Day', 'Week', 'Month' ), true ) &&
+		! empty( $level->billing_amount ) &&
+		! empty( $level->cycle_number ) &&
+		$credit > 0
+	) {
+		$old_cost_per_day = pmprorate_get_cost_per_day( $old_billing_amount, $old_cycle_number, $old_cycle_period );
+		$new_cost_per_day = pmprorate_get_cost_per_day( $level->billing_amount, $level->cycle_number, $level->cycle_period );
+
+		if ( $new_cost_per_day > $old_cost_per_day ) {
+			$free_days       = $credit / $new_cost_per_day;
+			$first_charge_ts = current_time( 'timestamp' ) + (int) ceil( $free_days * DAY_IN_SECONDS );
+			$first_charge_date = date_i18n( 'Y-m-d H:i:s', $first_charge_ts );
+
+			/**
+			 * Filter the first-charge date applied when an annual → shorter-period
+			 * upgrade uses credit-as-time delay. Default is today + (remaining
+			 * credit / new level's daily rate).
+			 *
+			 * Return null/false to skip the credit-as-time delay entirely and
+			 * fall through to the standard different-period proration logic.
+			 *
+			 * @since 1.1
+			 *
+			 * @param string $first_charge_date 'Y-m-d H:i:s' date.
+			 * @param float  $credit            Remaining credit from the old subscription.
+			 * @param float  $new_cost_per_day  Per-day cost of the new level.
+			 * @param object $level             The level being purchased.
+			 * @param object $clevel            The level being switched from.
+			 */
+			$first_charge_date = apply_filters(
+				'pmprorate_credit_delay_first_charge_date',
+				$first_charge_date,
+				$credit,
+				$new_cost_per_day,
+				$level,
+				$clevel
+			);
+
+			if ( ! empty( $first_charge_date ) ) {
+				$level->initial_payment = 0;
+
+				if ( defined( 'PMPRO_VERSION' ) && version_compare( PMPRO_VERSION, '3.4', '>=' ) ) {
+					$level->profile_start_date = $first_charge_date;
+				} else {
+					// PMPro 3.0-3.3: route the deferred date through the older filter API.
+					$level->_pmprorate_credit_first_charge = $first_charge_date;
+					add_filter( 'pmpro_profile_start_date', 'pmprorate_credit_delay_set_start_date', 10, 2 );
+				}
+
+				return $level;
+			}
+		}
+	}
+
 	// If changing to a level with a different payment period, keep the "next payment date" the same.
 	if ( pmprorate_have_same_payment_period( $clevel, $level ) ) {
 		/*
@@ -302,6 +386,25 @@ function pmprorate_pmpro_checkout_level( $level ) {
 	return $level;
 }
 add_filter( "pmpro_checkout_level", "pmprorate_pmpro_checkout_level", 10, 1 );
+
+/**
+ * Set the start date for the new subscription when credit-as-time delay
+ * is applied during an annual → shorter-period upgrade. Used on PMPro
+ * 3.0-3.3, where setting the `profile_start_date` property on the level
+ * object is not read by gateways. PMPro 3.4+ uses the property directly.
+ *
+ * @since 1.1
+ *
+ * @param string $startdate The start date for the membership.
+ * @param object $order     The order that is being purchased.
+ * @return string
+ */
+function pmprorate_credit_delay_set_start_date( $startdate, $order ) {
+	if ( ! empty( $order->membership_level->_pmprorate_credit_first_charge ) ) {
+		return $order->membership_level->_pmprorate_credit_first_charge;
+	}
+	return $startdate;
+}
 
 /**
  * Set the date that the first recurring payment will be charged.

--- a/pmpro-proration.php
+++ b/pmpro-proration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Paid Memberships Pro - Proration Add On
  * Plugin URI: http://www.paidmembershipspro.com/wp/pmpro-proration/
  * Description: Simple proration for membership level upgrades and downgrades.
- * Version: 1.0.3
+ * Version: 1.1.0
  * Author: Paid Memberships Pro
  * Author URI: https://www.paidmembershipspro.com
  * Text Domain: pmpro-proration

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: strangerstudios
 Tags: pmpro, paid memberships pro, members, memberships, prorated, prorate, proration, upgrade, downgrade
 Requires at least: 3.0
 Tested up to: 6.9
-Stable tag: 1.0.3
+Stable tag: 1.1.0
 
 Simple proration for membership upgrades and downgrades to maintain a member's payment date and adjust initial payment at membership checkout.
 
@@ -23,6 +23,9 @@ For sites that are using PMPro v3.0+, prorated amounts are calculated based on t
 1. Activate the plugin through the 'Plugins' menu in WordPress.
 
 == Changelog ==
+= 1.1.0 - TBD =
+* ENHANCEMENT: Annual → shorter-period upgrades now use a "credit-as-time" delay so members don't forfeit the unused portion of an annual prepayment. When a member with an active annual subscription checks out for a recurring level with a shorter cycle (Month/Week/Day) that costs more per day, the initial payment is set to $0 and the new subscription's first billing date is deferred by the number of days the remaining annual credit buys at the new daily rate. Downgrades by cost-per-day continue to use the existing delayed-downgrade flow. Filter `pmprorate_credit_delay_first_charge_date` to customize.
+
 = 1.0.3 - 2026-05-04 =
 * ENHANCEMENT: Updated all 5 delayed-downgrade email templates to use the new Liquid `{{ variable }}` syntax when running PMPro 3.7 or later, while still falling back to the legacy `!!variable!!` syntax on older versions of PMPro. Default email bodies now use the same `wp_kses_post( __( ... ) )` pattern as PMPro core. #36 (@dparker1005)
 * BUG FIX: Fixed an issue where the delayed downgrade level could be incorrectly recorded as the level being downgraded from (instead of the level being downgraded to) on Stripe onsite checkouts when the Affiliates Add On was active. #37 (@dwanjuki)


### PR DESCRIPTION
## Summary

When a member with an active annual subscription checks out for a recurring level with a shorter cycle (Day/Week/Month) that costs **more per day** than the annual, the current behavior either charges the full new-level initial today (squandering any unused annual credit) or — when the credit happens to exceed the new initial — clamps the initial to $0 but still starts the new monthly subscription billing immediately. Either way, the customer forfeits the value of what they prepaid.

This PR adds a "credit-as-time delay" branch: charge $0 today, then defer the new subscription's first billing date by `(remaining annual credit / new cost per day)` days. The customer keeps the full value of their prepayment, converted to access at the new rate. The same delayed-downgrade plumbing is reused so it works on Stripe, PayPal, and any other gateway that respects `profile_start_date` (3.4+) or `pmpro_profile_start_date` (3.0-3.3).

### Example

Member is on **Plus Annual ($599/yr)**, ~6 months into the year (~$300 of credit remaining). They want to switch to **Max Monthly ($99/mo)** for more features.

| | Before | After |
|---|---|---|
| Charged today | $99 (different-period proration clamped) | $0 |
| Next billing date | Today + 1 month | Today + 92 days |
| Next billing amount | $99 | $99 |

After the deferral runs out, normal $99/mo recurring kicks in. No refund, no double-billing, no lost credit.

## Behavior preserved

- Cost-per-day downgrades (e.g. Plus annual → Standard monthly): unchanged — still uses delayed-downgrade flow (keeps the annual until renewal, then drops to the cheaper level).
- Monthly → annual: unchanged — pays prorated annual today.
- Same-period cross-level (Standard monthly → Plus monthly, Plus annual → Max annual): unchanged.

## Filter

`pmprorate_credit_delay_first_charge_date( string $date, float $credit, float $new_cpd, object $level, object $clevel )` — customize the deferred date. Returning `null`/`false` falls back to the standard different-period proration logic.

## Tested on

PMPro 3.7.x + pmpro-payment-plans on a local test site with 30 seeded members across (Standard / Plus / Max) × (monthly / annual). Full 6×6 transition matrix verified — 6 previously-broken cells now produce the new behavior, 24 unchanged cells produce identical results to before.

## Test plan

- [ ] Stripe sandbox: confirm `profile_start_date` is honored as trial-days on subscription creation
- [ ] PayPal Express: confirm the same
- [ ] Discount-code interaction: code on the new monthly level should reduce `\$level->billing_amount`, giving the customer more free days from their annual credit (this happens automatically — no extra code needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)