### PR TITLE
Skip proration for past-due subscriptions; process downgrades on payment completion

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -156,6 +156,33 @@ function pmprorate_pmpro_checkout_level( $level ) {
 		return $level;
 	}
 
+	// In PMPro v3.0+, get the user's current subscription for the level being switched from
+	// once here so the rest of this function doesn't have to refetch it.
+	$current_subscription = null;
+	if ( class_exists( 'PMPro_Subscription' ) ) {
+		$current_subscriptions = PMPro_Subscription::get_subscriptions_for_user( $current_user->ID, $clevel_id );
+		$current_subscription  = empty( $current_subscriptions ) ? null : current( $current_subscriptions );
+
+		// Without an active subscription for the level being switched from there is nothing to
+		// prorate against (no billing amount or next payment date to work from), so let the
+		// checkout proceed normally.
+		if ( empty( $current_subscription ) ) {
+			return $level;
+		}
+
+		// If that subscription is "past due", skip proration. Everything below assumes the
+		// member has paid through their current billing period: it credits the unused portion
+		// of that period and/or defers billing to the subscription's next payment date. Once a
+		// recurring payment has failed none of those assumptions hold -- the most recent order
+		// may even be the failed/`pending` payment itself, which would credit money that was
+		// never collected -- so we let the checkout proceed normally at full price with a new
+		// subscription. PMPro saves a `pending` order whenever a recurring payment fails (since
+		// PMPro 3.6) and core treats any pending order as a missed payment, so we do the same.
+		if ( ! empty( $current_subscription->get_orders( array( 'status' => 'pending', 'limit' => 1 ) ) ) ) {
+			return $level;
+		}
+	}
+
 	// Check if the user should get a delayed downgrade.
 	// This will only work for v3.0+. Otherwise, default migration logic will set the initial payment to $0.
 	if ( class_exists( 'PMPro_Subscription' ) && pmprorate_isDowngrade( $clevel, $level ) ) {
@@ -170,11 +197,8 @@ function pmprorate_pmpro_checkout_level( $level ) {
 		// If purchasing a subscription, make sure payment date stays the same.
 		// Check if we are using PMPro v3.4+. That version starts supporting the `profile_start_date` property on the level object.
 		if ( defined( 'PMPRO_VERSION' ) && version_compare( PMPRO_VERSION, '3.4', '>=' ) ) {
-			// Get the subscription.
-			$current_subscriptions = PMPro_Subscription::get_subscriptions_for_user( get_current_user_id(), $clevel_id );
-
 			// Use the new `profile_start_date` property on the level object.
-			$level->profile_start_date = empty( $current_subscriptions ) ? null : $current_subscriptions[0]->get_next_payment_date( 'Y-m-d H:i:s' );
+			$level->profile_start_date = $current_subscription->get_next_payment_date( 'Y-m-d H:i:s' );
 
 			// Remember the fact that this is a downgrade.
 			$level->pmprorate_is_downgrade = true;
@@ -192,18 +216,7 @@ function pmprorate_pmpro_checkout_level( $level ) {
 
 	// Getting the next payment date and most recent order has different logic for PMPro v2.x and v3.0+.
 	if ( class_exists( 'PMPro_Subscription' ) ) {
-		// Using PMPro v3.0+.
-		// Get the user's current subscription.
-		$current_subscriptions = PMPro_Subscription::get_subscriptions_for_user( get_current_user_id(), $clevel_id );
-
-		// No prorating needed if they don't have a subscription.
-		if ( empty( $current_subscriptions ) ) {
-			return $level;
-		}
-
-		// Get the current subscription.
-		$current_subscription = current( $current_subscriptions );
-
+		// Using PMPro v3.0+. We have already returned above if there is no current subscription.
 		// Get the last payment date and next payment date.
 		$newest_orders = $current_subscription->get_orders( array( 'limit' => 1 ) );
 		if ( empty( $newest_orders ) ) {

--- a/includes/delayed-downgrades.php
+++ b/includes/delayed-downgrades.php
@@ -16,7 +16,7 @@ function pmprorate_init_downgrades() {
 	add_filter( 'pmpro_checkout_before_change_membership_level', 'pmprorate_checkout_before_change_membership_level_remember_downgrade', 20, 2 ); // Priority 20 to run after offsite payment gateway redirects.
 
 	// Hook functions to process downgrades.
-	add_action( 'pmpro_added_order', 'pmprorate_added_order_process_downgrade' ); // Running after the order is created so that the new order gets its membership ID changed to the new level.
+	add_action( 'pmpro_subscription_payment_completed', 'pmprorate_subscription_payment_completed_process_downgrade' ); // Process a scheduled downgrade when the subscription's next recurring payment is successfully collected.
 	add_action( 'pmpro_membership_pre_membership_expiry', 'pmprorate_membership_pre_membership_expiry', 10, 2 );
 
 	// Hook function to remove downgrade if the corresponding level is lost.
@@ -286,15 +286,20 @@ function pmprorate_member_edit_panels_downgrades( $panels ) {
 }
 
 /**
- * When an order is created, check if is a part of a subscription.
- * If so, check if the subscription has a downgrade order linked.
- * If so, process the downgrade.
+ * When a subscription's recurring payment is successfully collected, check if the
+ * subscription has a pending downgrade and, if so, process it.
+ *
+ * Hooked to `pmpro_subscription_payment_completed`, which only fires for a successfully
+ * collected recurring payment -- never for the initial checkout order and never for the
+ * `pending` order PMPro saves on a failed payment. A failed/"past due" renewal therefore
+ * cannot trigger the downgrade; it stays pending until a payment clears or the membership
+ * expires.
  *
  * @since 1.0
  *
- * @param MemberOrder $order The order object.
+ * @param MemberOrder $order The order for the recurring payment that was just processed.
  */
- function pmprorate_added_order_process_downgrade( $order ) {
+ function pmprorate_subscription_payment_completed_process_downgrade( $order ) {
 	// Get the subscription for this order.
 	$subscription = $order->get_subscription();
 	if ( empty( $subscription ) ) {


### PR DESCRIPTION
## Summary

Two related fixes to the delayed-downgrade / proration flow, both centered on subscriptions that are **past due** (have a failed/missed recurring payment).

### 1. Skip proration for past-due subscriptions (`includes/checkout.php`)

`pmprorate_pmpro_checkout_level()` now fetches the current subscription once at the top and **skips proration when that subscription is past due**.

PMPro records a `pending` order whenever a recurring payment fails (since PMPro 3.6), and core treats the presence of any pending order on a subscription as a missed payment (see `pmpro_handle_recurring_payment_failure_at_gateway()` and the cancellation flows). The proration math assumes the member has paid through their current billing period — it credits unused time and/or defers billing to the next payment date — which is not true once a renewal has failed. In the worst case the most recent order is the failed payment itself, so the credit calculation would credit money that was never collected. When the subscription is past due we now let the checkout proceed at full price with a fresh subscription.

This also consolidates the `$current_subscription` lookup (previously fetched up to three times in the function) and adds an explicit "no subscription → no proration" bail.

### 2. Process delayed downgrades on payment completion, not order creation (`includes/delayed-downgrades.php`)

Delayed-downgrade processing moves from `pmpro_added_order` to `pmpro_subscription_payment_completed`.

`pmpro_subscription_payment_completed` only fires for a **successfully collected recurring payment** — never for the initial checkout order, and never for the `pending` order PMPro saves on a failed payment. `pmpro_added_order`, by contrast, began firing on failed renewals once PMPro 3.6 started recording failed payments as pending orders, which could trigger a downgrade prematurely. Switching hooks fixes that and removes the need for order-status / past-due guards in the processing function. The action has existed since 2013 (with the `$order` argument since 2016), so it is safely available on the plugin's `Requires at least: 3.0` baseline.

## Behavior note

`pmpro_subscription_payment_completed` is fired by all core recurring gateways (Stripe, PayPal, Braintree, Authorize.net, 2Checkout). Gateways where renewals are recorded manually (e.g. Pay by Check) do not fire it, so a delayed downgrade on such a subscription now processes via the membership-expiration path rather than at the moment of the manual payment. This is not a regression — the previous `pmpro_added_order` hook did not handle those renewals correctly either — and the expiration path remains the backstop.

## Testing

- `php -l` passes on both files.
- Verified gateway coverage, re-entrancy (the async checkout in `process()` does not re-fire the hook), and ordering vs. core's `update_subscription_for_order` (which only syncs gateway fields and runs first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
